### PR TITLE
fix: Update IProp types to fix yarn build

### DIFF
--- a/examples/next-app/components/setting.tsx
+++ b/examples/next-app/components/setting.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, Dispatch, SetStateAction } from "react";
 import { CHAIN_CONFIG, CHAIN_CONFIG_TYPE } from "../config/chainConfig";
 import { WEB3AUTH_NETWORK, WEB3AUTH_NETWORK_TYPE } from "../config/web3AuthNetwork";
 import styles from "../styles/Home.module.css";
@@ -6,8 +6,8 @@ import { Web3AuthContext } from "../services/web3auth";
 import { useContext } from "react";
 
 interface IProps {
-  setNetwork: (network: WEB3AUTH_NETWORK_TYPE) => void;
-  setChain: (chain: CHAIN_CONFIG_TYPE) => void;
+  setNetwork: Dispatch<SetStateAction<WEB3AUTH_NETWORK_TYPE>>;
+  setChain: Dispatch<SetStateAction<CHAIN_CONFIG_TYPE>>;
 }
 
 const Setting = ({ setNetwork, setChain }: IProps) => {


### PR DESCRIPTION
While cloning this repo to reproduce my issue, the yarn build command was failing out of the box. I updated the types in my repo to get it to work and I'm creating this PR for the fix :)

## Before the fix
`yarn build` was failing

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/62167899/157651211-062b8b0c-cd89-4e42-baf3-b5ef8513d3f9.png">

## After the fix 
`yarn build` works! ✅

<img width="1072" alt="image" src="https://user-images.githubusercontent.com/62167899/157651362-758ee647-f849-4d1c-a476-324f64a28c1d.png">

