### PR TITLE
priv key provider support for other chains

### DIFF
--- a/packages/base/src/chain/IChainInterface.ts
+++ b/packages/base/src/chain/IChainInterface.ts
@@ -1,12 +1,14 @@
 export const CHAIN_NAMESPACES = {
   EIP155: "eip155",
   SOLANA: "solana",
+  OTHER: "other",
 } as const;
 // eip155 for all evm chains
 export type ChainNamespaceType = typeof CHAIN_NAMESPACES[keyof typeof CHAIN_NAMESPACES];
 
 export const ADAPTER_NAMESPACES = {
-  ...CHAIN_NAMESPACES,
+  EIP155: "eip155",
+  SOLANA: "solana",
   MULTICHAIN: "multichain",
 } as const;
 // eip155 for all evm chains

--- a/packages/base/src/chain/config.ts
+++ b/packages/base/src/chain/config.ts
@@ -144,12 +144,12 @@ export const getSolanaChainConfig = (chainId: number): CustomChainConfig | null 
 };
 
 export const getChainConfig = (chainNamespace: ChainNamespaceType, chainId?: number | string): CustomChainConfig | null => {
+  if (chainNamespace === CHAIN_NAMESPACES.OTHER) return null;
   const finalChainId = chainId ? (typeof chainId === "number" ? chainId : parseInt(chainId, 16)) : getDefaultNetworkId(chainNamespace);
   if (chainNamespace === CHAIN_NAMESPACES.EIP155) {
     return getEvmChainConfig(finalChainId);
   } else if (chainNamespace === CHAIN_NAMESPACES.SOLANA) {
     return getSolanaChainConfig(finalChainId);
   }
-
   return null;
 };

--- a/packages/core/src/core.ts
+++ b/packages/core/src/core.ts
@@ -63,7 +63,7 @@ export class Web3AuthCore extends SafeEventEmitter implements IWeb3Auth {
     this.coreOptions = {
       ...options,
       chainConfig: {
-        ...getChainConfig(options.chainConfig?.chainNamespace, options.chainConfig?.chainId),
+        ...(getChainConfig(options.chainConfig?.chainNamespace, options.chainConfig?.chainId) || {}),
         ...options.chainConfig,
       },
     };

--- a/packages/modal/src/config.ts
+++ b/packages/modal/src/config.ts
@@ -79,3 +79,15 @@ export const defaultEvmWalletModalConfig: AdaptersModalConfig = {
     },
   },
 };
+
+export const defaultOtherModalConfig: AdaptersModalConfig = {
+  chainNamespace: CHAIN_NAMESPACES.OTHER,
+  adapters: {
+    [EVM_ADAPTERS.OPENLOGIN]: {
+      label: "OpenLogin",
+      showOnModal: true,
+      showOnMobile: true,
+      showOnDesktop: true,
+    },
+  },
+};

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -14,7 +14,13 @@ import {
 import { Web3AuthCore, Web3AuthCoreOptions } from "@web3auth/core";
 import LoginModal, { getAdapterSocialLogins, LOGIN_MODAL_EVENTS, OPENLOGIN_PROVIDERS } from "@web3auth/ui";
 
-import { defaultEvmDappModalConfig, defaultEvmWalletModalConfig, defaultSolanaDappModalConfig, defaultSolanaWalletModalConfig } from "./config";
+import {
+  defaultEvmDappModalConfig,
+  defaultEvmWalletModalConfig,
+  defaultOtherModalConfig,
+  defaultSolanaDappModalConfig,
+  defaultSolanaWalletModalConfig,
+} from "./config";
 import { getDefaultAdapterModule } from "./default";
 import { AdaptersModalConfig, ModalConfig } from "./interface";
 
@@ -94,6 +100,8 @@ export class Web3Auth extends Web3AuthCore {
         // default config for evm dapp modal
         this.modalConfig = defaultEvmDappModalConfig;
       }
+    } else if (providedChainConfig.chainNamespace === CHAIN_NAMESPACES.OTHER) {
+      this.modalConfig = defaultOtherModalConfig;
     } else {
       throw new Error(`Invalid chainNamespace provided: ${providedChainConfig.chainNamespace}`);
     }

--- a/packages/providers/base-provider/src/commonPrivateKeyProvider.ts
+++ b/packages/providers/base-provider/src/commonPrivateKeyProvider.ts
@@ -1,0 +1,71 @@
+import { createEventEmitterProxy, providerFromEngine, SafeEventEmitterProvider } from "@toruslabs/base-controllers";
+import { createAsyncMiddleware, createScaffoldMiddleware, JRPCEngine, JRPCMiddleware, JRPCRequest, JRPCResponse } from "@toruslabs/openlogin-jrpc";
+import { CustomChainConfig } from "@web3auth/base";
+
+import { IBaseProvider } from "./IBaseProvider";
+
+export class CommonPrivateKeyProvider implements IBaseProvider<string> {
+  // should be Assigned in setupProvider
+  public _providerEngineProxy: SafeEventEmitterProvider | null = null;
+
+  get provider(): SafeEventEmitterProvider | null {
+    return this._providerEngineProxy;
+  }
+
+  set provider(_) {
+    throw new Error("Method not implemented.");
+  }
+
+  public static getProviderInstance = async (params: { privKey: string }): Promise<CommonPrivateKeyProvider> => {
+    const providerFactory = new CommonPrivateKeyProvider();
+    await providerFactory.setupProvider(params.privKey);
+    return providerFactory;
+  };
+
+  addChain(_: CustomChainConfig): void {
+    throw new Error("Method not implemented.");
+  }
+
+  public async setupProvider(privKey: string): Promise<void> {
+    const privKeyMiddleware = this.getPrivKeyMiddleware(privKey);
+    const engine = new JRPCEngine();
+    engine.push(privKeyMiddleware);
+    const provider = providerFromEngine(engine);
+    this.updateProviderEngineProxy(provider);
+  }
+
+  public async switchChain(_: { chainId: string }): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected getProviderEngineProxy(): SafeEventEmitterProvider | null {
+    return this._providerEngineProxy;
+  }
+
+  protected updateProviderEngineProxy(providerEngineProxy: SafeEventEmitterProvider) {
+    if (this._providerEngineProxy) {
+      (this._providerEngineProxy as any).setTarget(providerEngineProxy);
+    } else {
+      this._providerEngineProxy = createEventEmitterProxy<SafeEventEmitterProvider>(providerEngineProxy);
+    }
+  }
+
+  private getPrivKeyMiddleware(privKey: string): JRPCMiddleware<unknown, unknown> {
+    const middleware = {
+      getPrivatekey: async (): Promise<string> => {
+        return privKey;
+      },
+    };
+    return this.createPrivKeyMiddleware(middleware);
+  }
+
+  private createPrivKeyMiddleware({ getPrivatekey }): JRPCMiddleware<unknown, unknown> {
+    async function getPrivatekeyHandler(_: JRPCRequest<{ privateKey: string }[]>, res: JRPCResponse<unknown>): Promise<void> {
+      res.result = await getPrivatekey();
+    }
+
+    return createScaffoldMiddleware({
+      private_key: createAsyncMiddleware(getPrivatekeyHandler),
+    });
+  }
+}

--- a/packages/providers/base-provider/src/index.ts
+++ b/packages/providers/base-provider/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./baseProvider";
+export * from "./commonPrivateKeyProvider";
 export * from "./IBaseProvider";
 export * from "./utils";


### PR DESCRIPTION
- Feature:-
  - This feature adds a new chain namespace named "other" to support other chains except evm and solana.
  
  - If user will be pass other namespace then only social logins can be used and creating connection with chain is not required.
  
  - On  successful connection , Adapter will return a provider which has just one method to return private key.
  
  - Rpc Method to get private key is "private_key"
