### PR TITLE
Update configs for different chainIds

### DIFF
--- a/demo/vue-app/src/rpc/ethRpc.vue
+++ b/demo/vue-app/src/rpc/ethRpc.vue
@@ -35,7 +35,6 @@
 </template>
 
 <script lang="ts">
-import { DEFAULT_INFURA_ID } from "@web3auth/base";
 import Vue from "vue";
 
 import { getAccounts, getBalance, getChainId, sendEth, signEthMessage, signTransaction } from "../lib/eth";
@@ -95,7 +94,7 @@ export default Vue.extend({
                 symbol: "ETH",
                 decimals: 18,
               },
-              rpcUrls: [`https://rinkeby.infura.io/v3/${DEFAULT_INFURA_ID}`],
+              rpcUrls: [`https://rpc.ankr.com/eth_rinkeby`],
               blockExplorerUrls: [`https://rinkeby.etherscan.io/`],
             },
           ],

--- a/packages/base/src/chain/config.ts
+++ b/packages/base/src/chain/config.ts
@@ -15,7 +15,7 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
     return {
       chainNamespace,
       chainId: "0x1",
-      rpcTarget: `https://mainnet.infura.io/v3/${DEFAULT_INFURA_ID}`,
+      rpcTarget: `https://rpc.ankr.com/eth`,
       displayName: "Ethereum Mainnet",
       blockExplorer: "https://etherscan.io/",
       ticker: "ETH",
@@ -25,7 +25,7 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
     return {
       chainNamespace,
       chainId: "0x3",
-      rpcTarget: `https://ropsten.infura.io/v3/${DEFAULT_INFURA_ID}`,
+      rpcTarget: `https://rpc.ankr.com/eth_ropsten`,
       displayName: "ropsten",
       blockExplorer: "https://ropsten.etherscan.io/",
       ticker: "ETH",
@@ -35,7 +35,7 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
     return {
       chainNamespace,
       chainId: "0x4",
-      rpcTarget: `https://rinkeby.infura.io/v3/${DEFAULT_INFURA_ID}`,
+      rpcTarget: `https://rpc.ankr.com/eth_rinkeby`,
       displayName: "rinkeby",
       blockExplorer: "https://rinkeby.etherscan.io/",
       ticker: "ETH",
@@ -45,61 +45,191 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
     return {
       chainNamespace,
       chainId: "0x5",
-      rpcTarget: `https://goerli.infura.io/v3/${DEFAULT_INFURA_ID}`,
+      rpcTarget: `https://rpc.ankr.com/eth_goerli`,
       displayName: "goerli",
       blockExplorer: "https://goerli.etherscan.io/",
-      ticker: "ETH",
-      tickerName: "Ethereum",
-    };
-  } else if (chainId === 42) {
-    return {
-      chainNamespace,
-      chainId: "0x2a",
-      rpcTarget: `https://kovan.infura.io/v3/${DEFAULT_INFURA_ID}`,
-      displayName: "kovan",
-      blockExplorer: "https://kovan.etherscan.io/",
       ticker: "ETH",
       tickerName: "Ethereum",
     };
   } else if (chainId === 137) {
     return {
       chainNamespace,
-      rpcTarget: "https://polygon-rpc.com",
-      blockExplorer: "https://polygonscan.com",
       chainId: "0x89",
+      rpcTarget: "https://rpc.ankr.com/polygon",
       displayName: "Polygon Mainnet",
-      ticker: "matic",
-      tickerName: "matic",
+      blockExplorer: "https://polygonscan.com",
+      ticker: "MATIC",
+      tickerName: "Polygon",
     };
   } else if (chainId === 80001) {
     return {
       chainNamespace,
-      rpcTarget: "https://rpc-mumbai.maticvigil.com",
-      blockExplorer: "https://mumbai-explorer.matic.today",
       chainId: "0x13881",
+      rpcTarget: "https://rpc.ankr.com/polygon_mumbai",
       displayName: "Polygon Mumbai Testnet",
-      ticker: "matic",
-      tickerName: "matic",
+      blockExplorer: "https://mumbai.polygonscan.com/",
+      ticker: "MATIC",
+      tickerName: "Polygon",
     };
   } else if (chainId === 56) {
     return {
       chainNamespace,
-      rpcTarget: "https://bsc-dataseed.binance.org",
-      blockExplorer: "https://bscscan.com",
       chainId: "0x38",
+      rpcTarget: "https://rpc.ankr.com/bsc",
       displayName: "Binance SmartChain Mainnet",
+      blockExplorer: "https://bscscan.com",
       ticker: "BNB",
-      tickerName: "BNB",
+      tickerName: "Binance SmartChain",
     };
   } else if (chainId === 97) {
     return {
       chainNamespace,
-      rpcTarget: "https://data-seed-prebsc-2-s3.binance.org:8545",
-      blockExplorer: "https://testnet.bscscan.com",
       chainId: "0x61",
+      rpcTarget: "https://rpc.ankr.com/bsc_testnet_chapel",
       displayName: "Binance SmartChain Testnet",
+      blockExplorer: "https://testnet.bscscan.com",
       ticker: "BNB",
-      tickerName: "BNB",
+      tickerName: "Binance SmartChain",
+    };
+  } else if (chainId === 43114) {
+    return {
+      chainNamespace,
+      chainId: "0xA86A",
+      rpcTarget: "https://rpc.ankr.com/avalanche-c",
+      displayName: "Avalanche C-Chain Mainnet",
+      blockExplorer: "https://subnets.avax.network/c-chain",
+      ticker: "AVAX",
+      tickerName: "Avalanche C-Chain",
+    };
+  } else if (chainId === 43113) {
+    return {
+      chainNamespace,
+      chainId: "0xA869",
+      rpcTarget: "https://rpc.ankr.com/avalanche_fuji-c",
+      displayName: "Avalanche C-Chain Testnet",
+      blockExplorer: "https://subnets-test.avax.network/c-chain",
+      ticker: "AVAX",
+      tickerName: "Avalanche C-Chain",
+    };
+  } else if (chainId === 42161) {
+    return {
+      chainNamespace,
+      chainId: "0xA4B1",
+      rpcTarget: "https://rpc.ankr.com/arbitrum",
+      displayName: "Arbitrum Mainnet",
+      blockExplorer: "https://arbiscan.io",
+      ticker: "AETH",
+      tickerName: "Arbitrum",
+    };
+  } else if (chainId === 421611) {
+    return {
+      chainNamespace,
+      chainId: "0x66EEB",
+      rpcTarget: "https://rinkeby.arbitrum.io/rpc",
+      displayName: "Arbitrum Rinkeby Testnet",
+      blockExplorer: "https://testnet.arbiscan.io",
+      ticker: "AETH",
+      tickerName: "Arbitrum",
+    };
+  } else if (chainId === 10) {
+    return {
+      chainNamespace,
+      chainId: "0xA",
+      rpcTarget: "https://rpc.ankr.com/optimism",
+      displayName: "Optimism Mainnet",
+      blockExplorer: "https://optimistic.etherscan.io",
+      ticker: "OP",
+      tickerName: "Optimism",
+    };
+  } else if (chainId === 69) {
+    return {
+      chainNamespace,
+      chainId: "0x45",
+      rpcTarget: "https://rpc.ankr.com/optimism_testnet",
+      displayName: "Optimism Testnet",
+      blockExplorer: "https://kovan-optimistic.etherscan.io",
+      ticker: "OP",
+      tickerName: "Optimism",
+    };
+  } else if (chainId === 25) {
+    return {
+      chainNamespace,
+      chainId: "0x19",
+      rpcTarget: "https://rpc.cronos.org",
+      displayName: "Cronos Mainnet",
+      blockExplorer: "https://cronoscan.com/",
+      ticker: "CRO",
+      tickerName: "Cronos",
+    };
+  } else if (chainId === 338) {
+    return {
+      chainNamespace,
+      chainId: "0x152",
+      rpcTarget: "https://rpc-t3.cronos.org/",
+      displayName: "Cronos Testnet",
+      blockExplorer: "https://cronoscan.com/",
+      ticker: "CRO",
+      tickerName: "Cronos",
+    };
+  } else if (chainId === 1666600000) {
+    return {
+      chainNamespace,
+      chainId: "0x63564c40",
+      rpcTarget: "https://rpc.ankr.com/harmony",
+      displayName: "Harmony Mainnet",
+      blockExplorer: "https://explorer.harmony.one",
+      ticker: "ONE",
+      tickerName: "Harmony",
+    };
+  } else if (chainId === 42220) {
+    return {
+      chainNamespace,
+      chainId: "0xa4ec",
+      rpcTarget: "https://rpc.ankr.com/celo",
+      displayName: "Celo Mainnet",
+      blockExplorer: "https://explorer.celo.org",
+      ticker: "CELO",
+      tickerName: "Celo",
+    };
+  } else if (chainId === 1284) {
+    return {
+      chainNamespace,
+      chainId: "0x504",
+      rpcTarget: "https://rpc.ankr.com/moonbeam",
+      displayName: "Moonbeam Mainnet",
+      blockExplorer: "https://moonbeam.moonscan.io",
+      ticker: "GLMR",
+      tickerName: "Moonbeam",
+    };
+  } else if (chainId === 1287) {
+    return {
+      chainNamespace,
+      chainId: "0x507",
+      rpcTarget: "https://rpc.api.moonriver.moonbeam.network",
+      displayName: "Moonbeam Testnet",
+      blockExplorer: "https://moonbase.moonscan.io",
+      ticker: "GLMR",
+      tickerName: "Moonbeam",
+    };
+  } else if (chainId === 1285) {
+    return {
+      chainNamespace,
+      chainId: "0x505",
+      rpcTarget: "https://rpc.api.moonriver.moonbeam.network",
+      displayName: "Moonriver Mainnet",
+      blockExplorer: "https://moonriver.moonscan.io",
+      ticker: "MOVR",
+      tickerName: "Moonriver",
+    };
+  } else if (chainId === 8217) {
+    return {
+      chainNamespace,
+      chainId: "0x2019",
+      rpcTarget: "https://public-node-api.klaytnapi.com/v1/cypress",
+      displayName: "Klaytn Mainnet",
+      blockExplorer: "https://scope.klaytn.com",
+      ticker: "KLAY",
+      tickerName: "Klaytn",
     };
   }
 
@@ -111,32 +241,32 @@ export const getSolanaChainConfig = (chainId: number): CustomChainConfig | null 
   if (chainId === 1) {
     return {
       chainNamespace,
-      blockExplorer: "https://explorer.solana.com",
       chainId: "0x1",
+      rpcTarget: "https://rpc.ankr.com/solana",
       displayName: "Solana Mainnet",
-      rpcTarget: "https://api.mainnet-beta.solana.com",
+      blockExplorer: "https://explorer.solana.com",
       ticker: "SOL",
-      tickerName: "Solana Token",
+      tickerName: "Solana",
     };
   } else if (chainId === 2) {
     return {
-      rpcTarget: "https://api.testnet.solana.com",
-      blockExplorer: "https://explorer.solana.com?cluster=testnet",
-      chainId: "0x2",
       chainNamespace,
-      displayName: "testnet",
+      chainId: "0x2",
+      rpcTarget: "https://api.testnet.solana.com",
+      displayName: "Solana Testnet",
+      blockExplorer: "https://explorer.solana.com?cluster=testnet",
       ticker: "SOL",
-      tickerName: "solana",
+      tickerName: "Solana",
     };
   } else if (chainId === 3) {
     return {
-      rpcTarget: "https://api.devnet.solana.com",
-      blockExplorer: "https://explorer.solana.com?cluster=devnet",
-      chainId: "0x3",
       chainNamespace,
-      displayName: "devnet",
+      chainId: "0x3",
+      rpcTarget: "https://api.devnet.solana.com",
+      displayName: "Solana Devnet",
+      blockExplorer: "https://explorer.solana.com?cluster=devnet",
       ticker: "SOL",
-      tickerName: "solana",
+      tickerName: "Solana",
     };
   }
 

--- a/packages/base/src/chain/config.ts
+++ b/packages/base/src/chain/config.ts
@@ -1,5 +1,4 @@
 import { CHAIN_NAMESPACES, ChainNamespaceType, CustomChainConfig } from "./IChainInterface";
-export const DEFAULT_INFURA_ID = "776218ac4734478c90191dde8cae483c";
 const getDefaultNetworkId = (chainNamespace: ChainNamespaceType): number => {
   if (chainNamespace === CHAIN_NAMESPACES.EIP155) {
     return 1;
@@ -21,37 +20,41 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "ETH",
       tickerName: "Ethereum",
     };
-  } else if (chainId === 3) {
+  }
+  if (chainId === 3) {
     return {
       chainNamespace,
       chainId: "0x3",
       rpcTarget: `https://rpc.ankr.com/eth_ropsten`,
-      displayName: "ropsten",
+      displayName: "Ropsten Testnet",
       blockExplorer: "https://ropsten.etherscan.io/",
       ticker: "ETH",
       tickerName: "Ethereum",
     };
-  } else if (chainId === 4) {
+  }
+  if (chainId === 4) {
     return {
       chainNamespace,
       chainId: "0x4",
       rpcTarget: `https://rpc.ankr.com/eth_rinkeby`,
-      displayName: "rinkeby",
+      displayName: "Rinkeby Testnet",
       blockExplorer: "https://rinkeby.etherscan.io/",
       ticker: "ETH",
       tickerName: "Ethereum",
     };
-  } else if (chainId === 5) {
+  }
+  if (chainId === 5) {
     return {
       chainNamespace,
       chainId: "0x5",
       rpcTarget: `https://rpc.ankr.com/eth_goerli`,
-      displayName: "goerli",
+      displayName: "Goerli Testnet",
       blockExplorer: "https://goerli.etherscan.io/",
       ticker: "ETH",
       tickerName: "Ethereum",
     };
-  } else if (chainId === 137) {
+  }
+  if (chainId === 137) {
     return {
       chainNamespace,
       chainId: "0x89",
@@ -61,7 +64,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "MATIC",
       tickerName: "Polygon",
     };
-  } else if (chainId === 80001) {
+  }
+  if (chainId === 80001) {
     return {
       chainNamespace,
       chainId: "0x13881",
@@ -71,7 +75,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "MATIC",
       tickerName: "Polygon",
     };
-  } else if (chainId === 56) {
+  }
+  if (chainId === 56) {
     return {
       chainNamespace,
       chainId: "0x38",
@@ -81,7 +86,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "BNB",
       tickerName: "Binance SmartChain",
     };
-  } else if (chainId === 97) {
+  }
+  if (chainId === 97) {
     return {
       chainNamespace,
       chainId: "0x61",
@@ -91,67 +97,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "BNB",
       tickerName: "Binance SmartChain",
     };
-  } else if (chainId === 43114) {
-    return {
-      chainNamespace,
-      chainId: "0xA86A",
-      rpcTarget: "https://rpc.ankr.com/avalanche-c",
-      displayName: "Avalanche C-Chain Mainnet",
-      blockExplorer: "https://subnets.avax.network/c-chain",
-      ticker: "AVAX",
-      tickerName: "Avalanche C-Chain",
-    };
-  } else if (chainId === 43113) {
-    return {
-      chainNamespace,
-      chainId: "0xA869",
-      rpcTarget: "https://rpc.ankr.com/avalanche_fuji-c",
-      displayName: "Avalanche C-Chain Testnet",
-      blockExplorer: "https://subnets-test.avax.network/c-chain",
-      ticker: "AVAX",
-      tickerName: "Avalanche C-Chain",
-    };
-  } else if (chainId === 42161) {
-    return {
-      chainNamespace,
-      chainId: "0xA4B1",
-      rpcTarget: "https://rpc.ankr.com/arbitrum",
-      displayName: "Arbitrum Mainnet",
-      blockExplorer: "https://arbiscan.io",
-      ticker: "AETH",
-      tickerName: "Arbitrum",
-    };
-  } else if (chainId === 421611) {
-    return {
-      chainNamespace,
-      chainId: "0x66EEB",
-      rpcTarget: "https://rinkeby.arbitrum.io/rpc",
-      displayName: "Arbitrum Rinkeby Testnet",
-      blockExplorer: "https://testnet.arbiscan.io",
-      ticker: "AETH",
-      tickerName: "Arbitrum",
-    };
-  } else if (chainId === 10) {
-    return {
-      chainNamespace,
-      chainId: "0xA",
-      rpcTarget: "https://rpc.ankr.com/optimism",
-      displayName: "Optimism Mainnet",
-      blockExplorer: "https://optimistic.etherscan.io",
-      ticker: "OP",
-      tickerName: "Optimism",
-    };
-  } else if (chainId === 69) {
-    return {
-      chainNamespace,
-      chainId: "0x45",
-      rpcTarget: "https://rpc.ankr.com/optimism_testnet",
-      displayName: "Optimism Testnet",
-      blockExplorer: "https://kovan-optimistic.etherscan.io",
-      ticker: "OP",
-      tickerName: "Optimism",
-    };
-  } else if (chainId === 25) {
+  }
+  if (chainId === 25) {
     return {
       chainNamespace,
       chainId: "0x19",
@@ -161,7 +108,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "CRO",
       tickerName: "Cronos",
     };
-  } else if (chainId === 338) {
+  }
+  if (chainId === 338) {
     return {
       chainNamespace,
       chainId: "0x152",
@@ -171,57 +119,8 @@ export const getEvmChainConfig = (chainId: number): CustomChainConfig | null => 
       ticker: "CRO",
       tickerName: "Cronos",
     };
-  } else if (chainId === 1666600000) {
-    return {
-      chainNamespace,
-      chainId: "0x63564c40",
-      rpcTarget: "https://rpc.ankr.com/harmony",
-      displayName: "Harmony Mainnet",
-      blockExplorer: "https://explorer.harmony.one",
-      ticker: "ONE",
-      tickerName: "Harmony",
-    };
-  } else if (chainId === 42220) {
-    return {
-      chainNamespace,
-      chainId: "0xa4ec",
-      rpcTarget: "https://rpc.ankr.com/celo",
-      displayName: "Celo Mainnet",
-      blockExplorer: "https://explorer.celo.org",
-      ticker: "CELO",
-      tickerName: "Celo",
-    };
-  } else if (chainId === 1284) {
-    return {
-      chainNamespace,
-      chainId: "0x504",
-      rpcTarget: "https://rpc.ankr.com/moonbeam",
-      displayName: "Moonbeam Mainnet",
-      blockExplorer: "https://moonbeam.moonscan.io",
-      ticker: "GLMR",
-      tickerName: "Moonbeam",
-    };
-  } else if (chainId === 1287) {
-    return {
-      chainNamespace,
-      chainId: "0x507",
-      rpcTarget: "https://rpc.api.moonriver.moonbeam.network",
-      displayName: "Moonbeam Testnet",
-      blockExplorer: "https://moonbase.moonscan.io",
-      ticker: "GLMR",
-      tickerName: "Moonbeam",
-    };
-  } else if (chainId === 1285) {
-    return {
-      chainNamespace,
-      chainId: "0x505",
-      rpcTarget: "https://rpc.api.moonriver.moonbeam.network",
-      displayName: "Moonriver Mainnet",
-      blockExplorer: "https://moonriver.moonscan.io",
-      ticker: "MOVR",
-      tickerName: "Moonriver",
-    };
-  } else if (chainId === 8217) {
+  }
+  if (chainId === 8217) {
     return {
       chainNamespace,
       chainId: "0x2019",


### PR DESCRIPTION
Solves #389

This might also solve RPC endpoint error for multiple people starting out with Web3Auth. Adds more evm chains anf removed rate limited infura endpoint.

I didn't remove `DEFAULT_INFURA_ID` since it is being exported from the web3auth base package. However, it might not be required any further as I see. Only the vue demo app is using it. Let me know if there's any other usage of it, otherwise I'll remove that as well.