### PR TITLE
Bump OpenLogin version

### DIFF
--- a/packages/adapters/openlogin-adapter/package.json
+++ b/packages/adapters/openlogin-adapter/package.json
@@ -38,7 +38,7 @@
     "@types/lodash.merge": "^4.6.7"
   },
   "dependencies": {
-    "@toruslabs/openlogin": "^2.4.0",
+    "@toruslabs/openlogin": "^2.6.0",
     "@toruslabs/openlogin-ed25519": "^2.0.0",
     "@web3auth/base": "^2.0.0",
     "@web3auth/base-provider": "^2.0.0",


### PR DESCRIPTION
## **Description**

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Bumps `@toruslabs/openlogin` to `^2.6.0` (latest) from `^2.4.0`. This fixes an issue I was having
with `no3PC`, which seemed to be the only way to get open login to work using ionic capacitor on
android!

Fixes # (issue) (Link github issue)
(Add jira ticket link)

## **Type of change**

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## **Screenshots**

Please add screenshots if applicable

## **Test Configuration**:

### Frontend

**_Device 1_**

- Device: [e.g. iPhone6]
- OS: [e.g. iOS]
- Browser [e.g. chrome, safari]
- Version [e.g. 22]

**_Device 2_**

- Device: [e.g. iPhone6]
- OS: [e.g. iOS]
- Browser [e.g. chrome, safari]
- Version [e.g. 22]

or

### Backend

Include postman test suite url or steps to run test cases

## **Checklist**

- [x] My code follows the style guidelines of this project.
- [ ] I've run lint and build scripts
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove that my feature works
- [ ] New and existing unit tests pass locally with my changes
