### PR TITLE
(fix): blank modal after disconnect

### DIFF
--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -31,7 +31,7 @@ import { createRoot } from "react-dom/client";
 
 import { getLoginModalAnalyticsProperties } from "../utils";
 import Widget from "./components/Widget";
-import { DEFAULT_LOGO_DARK, DEFAULT_LOGO_LIGHT, DEFAULT_ON_PRIMARY_COLOR, DEFAULT_PRIMARY_COLOR } from "./constants";
+import { DEFAULT_LOGO_DARK, DEFAULT_LOGO_LIGHT, DEFAULT_ON_PRIMARY_COLOR, DEFAULT_PRIMARY_COLOR, PAGES } from "./constants";
 import { AnalyticsContext } from "./context/AnalyticsContext";
 import { ThemedContext } from "./context/ThemeContext";
 import {
@@ -421,6 +421,7 @@ export class LoginModal {
           status: MODAL_STATUS.CONNECTED,
           modalVisibility: true,
           postLoadingMessage: "modal.post-loading.connected",
+          currentPage: PAGES.LOGIN,
         });
       } else {
         this.setState({


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://consensyssoftware.atlassian.net/browse/W3APD-5144


## Description
<!--- Describe your changes in detail -->

- In external connect view mode, we depend on the Login component to be rendered as it enables the transition to connect wallet screen only.
- When we open the modal initially, the `current page` is login, then it changes to `connect_wallet`.
- When we connect to a wallet  and then disconnect, the current page still remains as `connect_wallet`.
- With this PR, we reset the `current_page` to `login`
- This enables the auto transition to connect wallet screen if there no social logins active.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

Devrels tested this

## Screenshots (if appropriate):

https://github.com/user-attachments/assets/ecd21f22-84d3-42d8-a90e-929501cd7dbb

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] My code requires a db migration.
