### PR TITLE
Fix: Disconnect state mismatch b/w web3auth sdk and wagmi

### DIFF
--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -22,10 +22,14 @@ import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
 
+function getWeb3authConnector(config: Config) {
+  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+}
+
 // Helper to initialize connectors for the given wallets
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
 
   if (connector) return connector;
 
@@ -72,10 +76,6 @@ async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
     current: connector.uid,
     status: "connected",
   }));
-}
-
-function getWeb3authConnector(config: Config) {
-  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
 }
 
 function resetConnectorState(config: Config) {

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -24,10 +24,14 @@ import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
 
+function getWeb3authConnector(config: Config) {
+  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+}
+
 // Helper to initialize connectors for the given wallets
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
 
   if (connector) return connector;
 
@@ -76,8 +80,15 @@ async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
   }));
 }
 
-async function disconnectWeb3AuthFromWagmi(config: Config) {
+function resetConnectorState(config: Config) {
   config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+}
+
+async function disconnectWeb3AuthFromWagmi(config: Config) {
+  const connector = getWeb3authConnector(config);
+  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
+  resetConnectorState(config);
   config.setState((state) => ({
     ...state,
     chainId: state.chainId,
@@ -97,6 +108,13 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
       if (isConnected) await disconnect();
+
+      const connector = getWeb3authConnector(wagmiConfig);
+      // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
+      // from the connected provider
+      if (connector) {
+        resetConnectorState(wagmiConfig);
+      }
     },
   });
 
@@ -191,7 +209,6 @@ export function WagmiProvider({ children, ...props }: PropsWithChildren<WagmiPro
       finalConfig.chains = [wagmiChains[0], ...wagmiChains.slice(1)];
     }
 
-    if (!finalConfig.chains) return;
     return createWagmiConfig(finalConfig);
   }, [config, web3Auth, isInitialized]);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://consensyssoftware.atlassian.net/browse/W3APD-5184


## Description
<!--- Describe your changes in detail -->

- After disconnecting from social login provider, we need to clear the wagmi connector state so that if we reconnect, we can setup the new connector with the new provider from web3auth
- Previously, if the state isn't cleared, the connector had the last provider state and if you change the provider type (like social to metamask), it wasn't working

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

devrels tested this

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
