### PR TITLE
Fix external wallet click not setting connector name and thus the previous one wrongly shows up

### DIFF
--- a/packages/modal/src/ui/components/Widget/Widget.tsx
+++ b/packages/modal/src/ui/components/Widget/Widget.tsx
@@ -91,7 +91,7 @@ function Widget(props: WidgetProps) {
     setModalState((prevState) => ({
       ...prevState,
       detailedLoaderConnector: connector,
-      detailedLoaderAdapterName: CONNECTOR_NAMES[connector as WALLET_CONNECTOR_TYPE],
+      detailedLoaderConnectorName: CONNECTOR_NAMES[connector as WALLET_CONNECTOR_TYPE],
     }));
 
     // Call the passed-in handler with the params


### PR DESCRIPTION
its due to setting it on the incorrect property instead of detailedLoaderConnectorName

<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link: https://consensyssoftware.atlassian.net/browse/W3APD-5227


## Description
<!--- Describe your changes in detail -->
### Scenario 1
Directly just clicking on MetaMask login shows "Verify your account to continue"

### Scenario 2
When clicking on google login and then MetaMask login, the message would continue to show "Verify your Google account to continue"

This PR fixes these 2 cases. Check the screenshots attached. As for other types of connectors e.g. phantom etc. the behaviour remains unchanged. In those cases it will continue to say "Verify your account to continue" since it is not part of this array
```javascript
export const CONNECTOR_NAMES = {
  [MULTI_CHAIN_CONNECTORS.AUTH]: "Auth",
  [MULTI_CHAIN_CONNECTORS.WALLET_CONNECT_V2]: "Wallet Connect v2",
  [EVM_CONNECTORS.COINBASE]: "Coinbase Smart Wallet",
  [EVM_CONNECTORS.METAMASK]: "MetaMask",
};
```


## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
### Scenario 1
**Before**
<img width="400" height="533" alt="Screenshot 2026-01-08 at 8 31 37 PM" src="https://github.com/user-attachments/assets/85c66496-c091-4d19-993e-55b6df8dc9b5" />

**After**
<img width="403" height="523" alt="Screenshot 2026-01-08 at 8 36 54 PM" src="https://github.com/user-attachments/assets/201d3a8b-b45b-40ca-b74d-451b02d98c32" />


### Scenario 2
**Before**
<img width="390" height="529" alt="Screenshot 2026-01-08 at 8 31 49 PM" src="https://github.com/user-attachments/assets/54c1b675-1d2d-497d-875c-870e1fb8b301" />
<img width="398" height="527" alt="Screenshot 2026-01-08 at 8 31 57 PM" src="https://github.com/user-attachments/assets/be6f3e76-9bde-43f0-b80f-6f90a2ff986f" />

**After**
<img width="414" height="535" alt="Screenshot 2026-01-08 at 8 30 08 PM" src="https://github.com/user-attachments/assets/d68f1132-35ba-4d00-a40a-40e315e531a2" />


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [ ] My code requires a db migration.
