### PR TITLE
fix: mitigate SSO session fixation with postMessage verification

### DIFF
--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -57,6 +57,9 @@ import { generateNonce, parseToken } from "../utils";
 import { AuthSolanaWallet } from "./authSolanaWallet";
 import type { AuthConnectorOptions, LoginSettings, PrivateKeyProvider, WalletServicesSettings } from "./interface";
 
+const WEB3AUTH_LOGIN_FINISHED = "web3auth_login_finished";
+const WEB3AUTH_LOGIN_ACK = "web3auth_login_ack";
+
 class AuthConnector extends BaseConnector<AuthLoginParams> {
   readonly name: WALLET_CONNECTOR_TYPE = WALLET_CONNECTORS.AUTH;
 
@@ -552,35 +555,61 @@ class AuthConnector extends BaseConnector<AuthLoginParams> {
     });
 
     return new Promise((resolve, reject) => {
-      verifierWindow.open().catch((error: unknown) => {
-        log.error("Error during login with social", error);
-        this.authInstance.postLoginCancelledMessage(nonce);
-        reject(error);
-      });
+      let loginFinished = false;
 
-      // this is to close the popup when the login is finished.
       const securePubSub = new SecurePubSub({
         sameIpCheck: true,
         serverUrl: this.authInstance.options.storageServerUrl,
         socketUrl: this.authInstance.options.sessionSocketUrl,
       });
+
+      const authServiceOrigin = new URL(this.authInstance.options.sdkUrl).origin;
+
+      const handleLoginFinished = (error?: string) => {
+        if (loginFinished) return;
+        loginFinished = true;
+        window.removeEventListener("message", handlePostMessage);
+        if (error) {
+          this.authInstance.postLoginCancelledMessage(nonce);
+          reject(error);
+        }
+        isClosedWindow = true;
+        securePubSub.cleanup();
+        verifierWindow.close();
+      };
+
+      const handlePostMessage = (event: MessageEvent) => {
+        if (event.origin !== authServiceOrigin) return;
+        if (event.data?.type !== WEB3AUTH_LOGIN_FINISHED) return;
+        if (event.data?.nonce !== nonce) return;
+        try {
+          (event.source as WindowProxy)?.postMessage({ type: WEB3AUTH_LOGIN_ACK, nonce }, authServiceOrigin);
+        } catch {
+          // best-effort ACK
+        }
+        handleLoginFinished(event.data?.error);
+      };
+
+      window.addEventListener("message", handlePostMessage);
+
+      verifierWindow.open().catch((error: unknown) => {
+        log.error("Error during login with social", error);
+        window.removeEventListener("message", handlePostMessage);
+        this.authInstance.postLoginCancelledMessage(nonce);
+        reject(error);
+      });
+
+      // SecurePubSub fallback for when window.opener is unavailable (e.g. COOP headers)
       securePubSub
         .subscribe(`web3auth-login-${nonce}`)
         .then((data: string) => {
           const parsedData = JSON.parse(data || "{}");
           if (parsedData?.message === "login_finished") {
-            if (parsedData?.error) {
-              this.authInstance.postLoginCancelledMessage(nonce);
-              reject(parsedData.error);
-            }
-            isClosedWindow = true;
-            securePubSub.cleanup();
-            verifierWindow.close();
+            handleLoginFinished(parsedData?.error);
           }
           return true;
         })
         .catch((error: unknown) => {
-          // swallow the error, dont need to throw.
           log.error("Error during login with social", error);
           this.auditOAuditProgress(loginParams as LoginParams, "failed").catch((error: unknown) => {
             log.error("Error reporting `oauthFailed` audit progress", error);
@@ -589,6 +618,7 @@ class AuthConnector extends BaseConnector<AuthLoginParams> {
 
       verifierWindow.once("close", () => {
         if (!isClosedWindow) {
+          window.removeEventListener("message", handlePostMessage);
           securePubSub.cleanup();
           this.authInstance.postLoginCancelledMessage(nonce);
           reject(WalletLoginError.popupClosed());

--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -57,6 +57,10 @@ import { generateNonce, parseToken } from "../utils";
 import { AuthSolanaWallet } from "./authSolanaWallet";
 import type { AuthConnectorOptions, LoginSettings, PrivateKeyProvider, WalletServicesSettings } from "./interface";
 
+const WEB3AUTH_LOGIN_FINISHED = "web3auth_login_finished";
+const WEB3AUTH_LOGIN_ACK = "web3auth_login_ack";
+const WEB3AUTH_LOGIN_OAUTH_DATA = "web3auth_login_oauth_data";
+
 class AuthConnector extends BaseConnector<AuthLoginParams> {
   readonly name: WALLET_CONNECTOR_TYPE = WALLET_CONNECTORS.AUTH;
 
@@ -552,35 +556,69 @@ class AuthConnector extends BaseConnector<AuthLoginParams> {
     });
 
     return new Promise((resolve, reject) => {
-      verifierWindow.open().catch((error: unknown) => {
-        log.error("Error during login with social", error);
-        this.authInstance.postLoginCancelledMessage(nonce);
-        reject(error);
-      });
+      let loginFinished = false;
 
-      // this is to close the popup when the login is finished.
       const securePubSub = new SecurePubSub({
         sameIpCheck: true,
         serverUrl: this.authInstance.options.storageServerUrl,
         socketUrl: this.authInstance.options.sessionSocketUrl,
       });
+
+      const authServiceOrigin = new URL(this.authInstance.options.sdkUrl).origin;
+
+      const handleLoginFinished = (error?: string) => {
+        if (loginFinished) return;
+        loginFinished = true;
+        window.removeEventListener("message", handlePostMessage);
+        if (error) {
+          this.authInstance.postLoginCancelledMessage(nonce);
+          reject(error);
+        }
+        isClosedWindow = true;
+        securePubSub.cleanup();
+        verifierWindow.close();
+      };
+
+      const handlePostMessage = (event: MessageEvent) => {
+        if (event.origin !== authServiceOrigin) return;
+        if (event.data?.type !== WEB3AUTH_LOGIN_FINISHED) return;
+        if (event.data?.nonce !== nonce) return;
+        try {
+          (event.source as WindowProxy)?.postMessage({ type: WEB3AUTH_LOGIN_ACK, nonce }, authServiceOrigin);
+        } catch {
+          // best-effort ACK
+        }
+        if (event.data?.data) {
+          try {
+            const authIframe = document.querySelector<HTMLIFrameElement>(`iframe[id^="auth-iframe-"]`);
+            authIframe?.contentWindow?.postMessage({ type: WEB3AUTH_LOGIN_OAUTH_DATA, nonce, data: event.data.data }, authServiceOrigin);
+          } catch {
+            // best-effort forward; Frame.vue SecurePubSub fallback handles this
+          }
+        }
+        handleLoginFinished(event.data?.error);
+      };
+
+      window.addEventListener("message", handlePostMessage);
+
+      verifierWindow.open().catch((error: unknown) => {
+        log.error("Error during login with social", error);
+        window.removeEventListener("message", handlePostMessage);
+        this.authInstance.postLoginCancelledMessage(nonce);
+        reject(error);
+      });
+
+      // SecurePubSub fallback for when window.opener is unavailable (e.g. COOP headers)
       securePubSub
         .subscribe(`web3auth-login-${nonce}`)
         .then((data: string) => {
           const parsedData = JSON.parse(data || "{}");
           if (parsedData?.message === "login_finished") {
-            if (parsedData?.error) {
-              this.authInstance.postLoginCancelledMessage(nonce);
-              reject(parsedData.error);
-            }
-            isClosedWindow = true;
-            securePubSub.cleanup();
-            verifierWindow.close();
+            handleLoginFinished(parsedData?.error);
           }
           return true;
         })
         .catch((error: unknown) => {
-          // swallow the error, dont need to throw.
           log.error("Error during login with social", error);
           this.auditOAuditProgress(loginParams as LoginParams, "failed").catch((error: unknown) => {
             log.error("Error reporting `oauthFailed` audit progress", error);
@@ -589,6 +627,7 @@ class AuthConnector extends BaseConnector<AuthLoginParams> {
 
       verifierWindow.once("close", () => {
         if (!isClosedWindow) {
+          window.removeEventListener("message", handlePostMessage);
           securePubSub.cleanup();
           this.authInstance.postLoginCancelledMessage(nonce);
           reject(WalletLoginError.popupClosed());


### PR DESCRIPTION
## Jira Link

N/A — Security vulnerability report response

## Description

Mitigates an SSO session fixation vulnerability in the popup login flow. The attack exploits SecurePubSub's server-side relay architecture: an attacker initiates OAuth, extracts the authorization URL, sends it to a victim, and receives the victim's credentials through the shared SecurePubSub channel.

**Changes:**
- Add a `postMessage` event listener in `connectWithSocialLogin` that receives `login_finished` directly from the popup via `window.opener.postMessage()`
- Validate the message origin (must match auth service URL) and nonce before accepting
- Send a `WEB3AUTH_LOGIN_ACK` back to the popup so it can skip the SecurePubSub dapp channel
- Retain SecurePubSub as a fallback for browsers where `window.opener` is unavailable (e.g. COOP headers)

**Companion PR:** Web3Auth/auth-service — sends the `postMessage` from the popup callback page and waits for ACK before deciding whether to use SecurePubSub.

## How has this been tested?

- Verified that the postMessage listener correctly validates origin, type, and nonce
- Verified cleanup of event listeners in all exit paths (success, error, popup closed)
- SecurePubSub fallback path preserved for backward compatibility

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the OAuth popup completion path in `AuthConnector.connectWithSocialLogin`, which is part of the authentication flow and security-sensitive. Incorrect origin/nonce handling or cleanup could break logins or reintroduce session-fixation style issues.
> 
> **Overview**
> **Mitigates a popup OAuth session-fixation vector** by preferring a direct `window.postMessage` signal from the auth-service popup over the shared `SecurePubSub` relay channel.
> 
> `connectWithSocialLogin` now listens for `web3auth_login_finished` messages, validates *origin* (auth service) and *nonce*, sends a `web3auth_login_ack` back to the popup, optionally forwards OAuth data to the auth iframe, and centralizes cleanup to ensure listeners/popup/pubsub are closed exactly once while retaining `SecurePubSub` as a compatibility fallback when `window.opener` is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f8365a6bcfbad26b1a39c10067e9a0fcc7825d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->