### PR TITLE
fix: authConnectionId overwrites in vue-app-new demo

### DIFF
--- a/demo/vue-app-new/src/MainView.vue
+++ b/demo/vue-app-new/src/MainView.vue
@@ -26,6 +26,7 @@ import {
   LocalStorageAdapter,
   MemoryStorage,
   SessionStorageAdapter,
+  WEB3AUTH_NETWORK,
   type BUILD_ENV_TYPE,
   type StorageConfig,
 } from "@web3auth/auth";
@@ -171,9 +172,9 @@ const options = computed((): Web3AuthOptions => {
 
 // Note: authConnectionId may varies based on the project config and web3auth client id.
 // The following function return the authConnectionId relevant to the AuthBuildEnv and `clientIds` Map from `config.ts`
+// we may need to change the values every time we change the web3auth client id or build environment.
 const getAuthConnectionIds = (authConnectionStr: string): { authConnectionId: string; groupedAuthConnectionId?: string } => {
-  if (authBuildEnv === BUILD_ENV.PRODUCTION) {
-    //
+  if (formData.network === WEB3AUTH_NETWORK.SAPPHIRE_MAINNET) {
     return {
       authConnectionId: "web3auth",
       groupedAuthConnectionId: `web3auth-auth0-${authConnectionStr}-passwordless-sapphire`,

--- a/demo/vue-app-new/src/MainView.vue
+++ b/demo/vue-app-new/src/MainView.vue
@@ -20,7 +20,15 @@ import { WagmiProvider } from "@web3auth/modal/vue/wagmi";
 import { coinbaseConnector } from "@web3auth/no-modal/connectors/coinbase-connector";
 import { computed, onBeforeMount, ref, watch } from "vue";
 
-import { BUILD_ENV, CookieStorage, LocalStorageAdapter, MemoryStorage, SessionStorageAdapter, type BUILD_ENV_TYPE, type StorageConfig } from "@web3auth/auth";
+import {
+  BUILD_ENV,
+  CookieStorage,
+  LocalStorageAdapter,
+  MemoryStorage,
+  SessionStorageAdapter,
+  type BUILD_ENV_TYPE,
+  type StorageConfig,
+} from "@web3auth/auth";
 import AppDashboard from "./components/AppDashboard.vue";
 import AppHeader from "./components/AppHeader.vue";
 import AppSettings from "./components/AppSettings.vue";
@@ -34,14 +42,10 @@ const formData = formDataStore;
 
 const externalConnectors = ref<ConnectorFn[]>([]);
 const buildEnvValues = new Set<BUILD_ENV_TYPE>(Object.values(BUILD_ENV));
-
-function resolveAuthBuildEnv(): BUILD_ENV_TYPE {
-  const envValue = import.meta.env.VITE_APP_AUTH_BUILD_ENV;
-  if (envValue && buildEnvValues.has(envValue as BUILD_ENV_TYPE)) {
-    return envValue as BUILD_ENV_TYPE;
-  }
-
-  return import.meta.env.DEV ? BUILD_ENV.TESTING : BUILD_ENV.PRODUCTION;
+const envValue = import.meta.env.VITE_APP_AUTH_BUILD_ENV;
+let authBuildEnv: BUILD_ENV_TYPE = import.meta.env.DEV ? BUILD_ENV.TESTING : BUILD_ENV.PRODUCTION;
+if (envValue && buildEnvValues.has(envValue as BUILD_ENV_TYPE)) {
+  authBuildEnv = envValue as BUILD_ENV_TYPE;
 }
 
 function buildStorageConfig(): StorageConfig | undefined {
@@ -152,7 +156,7 @@ const options = computed((): Web3AuthOptions => {
     chains,
     defaultChainId: formData.defaultChainId,
     enableLogging: true,
-    authBuildEnv: resolveAuthBuildEnv(),
+    authBuildEnv,
     connectors: [...externalConnectors.value, authConnectorInstance],
     plugins,
     multiInjectedProviderDiscovery: formData.multiInjectedProviderDiscovery,
@@ -165,13 +169,33 @@ const options = computed((): Web3AuthOptions => {
   };
 });
 
+// Note: authConnectionId may varies based on the project config and web3auth client id.
+// The following function return the authConnectionId relevant to the AuthBuildEnv and `clientIds` Map from `config.ts`
+const getAuthConnectionIds = (authConnectionStr: string): { authConnectionId: string; groupedAuthConnectionId?: string } => {
+  if (authBuildEnv === BUILD_ENV.PRODUCTION) {
+    //
+    return {
+      authConnectionId: "web3auth",
+      groupedAuthConnectionId: `web3auth-auth0-${authConnectionStr}-passwordless-sapphire`,
+    };
+  }
+  return {
+    authConnectionId: `w3a-custom-${authConnectionStr}-${formData.network.replace("_", "-")}`,
+  };
+};
+
 const loginMethodsConfig = computed(() => {
+  const { authConnectionId: customEmailAuthConnectionId, groupedAuthConnectionId: customEmailGroupedAuthConnectionId } =
+    getAuthConnectionIds("email");
+  const { authConnectionId: customSmsAuthConnectionId, groupedAuthConnectionId: customSmsGroupedAuthConnectionId } = getAuthConnectionIds("sms");
   const customConfig = {
     email_passwordless: {
-      authConnectionId: `w3a-custom-email-${formData.network.replace("_", "-")}`,
+      authConnectionId: customEmailAuthConnectionId,
+      groupedAuthConnectionId: customEmailGroupedAuthConnectionId,
     },
     sms_passwordless: {
-      authConnectionId: `w3a-custom-sms-${formData.network.replace("_", "-")}`,
+      authConnectionId: customSmsAuthConnectionId,
+      groupedAuthConnectionId: customSmsGroupedAuthConnectionId,
     },
   };
   if (formData.loginProviders.length === 0) return customConfig;
@@ -183,10 +207,12 @@ const loginMethodsConfig = computed(() => {
   }, {} as LoginMethodConfig);
 
   if (config.email_passwordless) {
-    config.email_passwordless.authConnectionId = `w3a-custom-email-${formData.network.replace("_", "-")}`;
+    config.email_passwordless.authConnectionId = customEmailAuthConnectionId;
+    config.email_passwordless.groupedAuthConnectionId = customEmailGroupedAuthConnectionId;
   }
   if (config.sms_passwordless) {
-    config.sms_passwordless.authConnectionId = `w3a-custom-sms-${formData.network.replace("_", "-")}`;
+    config.sms_passwordless.authConnectionId = customSmsAuthConnectionId;
+    config.sms_passwordless.groupedAuthConnectionId = customSmsGroupedAuthConnectionId;
   }
 
   const loginMethods: LoginMethodConfig = JSON.parse(JSON.stringify(config));


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Web3Auth login method connection ID generation in the demo; incorrect IDs would break passwordless login for certain networks/build envs, but scope is limited to demo configuration.
> 
> **Overview**
> Fixes the `vue-app-new` demo’s passwordless login configuration by centralizing `authConnectionId` generation and adding support for `groupedAuthConnectionId` (notably for `WEB3AUTH_NETWORK.SAPPHIRE_MAINNET`) so email/SMS methods don’t get overwritten or miscomputed across networks.
> 
> Also simplifies `authBuildEnv` resolution to a single initialization based on `VITE_APP_AUTH_BUILD_ENV` with a dev/prod fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fdbdeec05919ebc56822c0eb652669d2db6dd58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->