### PR TITLE
fix(security): cryptographic weakness - insecure prng used for authentication nonce in walletconnectv2connector

### DIFF
--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
@@ -308,7 +308,7 @@ class WalletConnectV2Connector extends BaseConnector<void> {
         address: accounts[0],
         chainId: parseInt(chainId, 16),
         version: "1",
-        nonce: Math.random().toString(36).slice(2),
+        nonce: crypto.randomUUID().replace(/-/g, ''),
         issuedAt: new Date().toISOString(),
       };
 


### PR DESCRIPTION
### Security Finding: Cryptographic Weakness: Insecure PRNG used for Authentication Nonce in WalletConnectV2Connector

**Severity:** MEDIUM
**Reported by:** FailSafe Research Team
**Component:** `packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts:311`

### Description

The `getAuthTokenInfo` method in the `WalletConnectV2Connector` class generates an authentication payload that includes a `nonce` to prevent replay attacks during the wallet authentication process. However, it uses the built-in `Math.random()` function to generate this nonce. `Math.random()` is a cryptographically weak pseudo-random number generator (PRNG) that produces predictable sequences of numbers. An attacker who can observe a few generated nonces or determine the internal state of the PRNG can accurately predict future nonces. This predictability completely undermines the security guarantees of the challenge-response authentication mechanism, allowing an attacker to pre-compute valid authentication payloads or execute sophisticated replay attacks against the system.

```
 306            domain: window.location.origin,
 307            uri: window.location.href,
 308            address: accounts[0],
 309            chainId: parseInt(chainId, 16),
 310            version: "1",
 311>>>         nonce: Math.random().toString(36).slice(2),
 312            issuedAt: new Date().toISOString(),
 313          };
 314    
 315          const authServer = citadelServerUrl(this.coreOptions.authBuildEnv);
 316          const challenge = await signChallenge(payload, chainNamespace, authServer);
```

### Fix

Replace the insecure `Math.random()` implementation with a cryptographically secure pseudo-random number generator (CSPRNG) provided by the Web Crypto API. Use `window.crypto.getRandomValues()` to generate a secure byte array and encode it, or use `crypto.randomUUID()` to generate a secure, unique identifier for the nonce. Example: `nonce: crypto.randomUUID().replace(/-/g, '')`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication challenge payload generation; while the change is small, nonce format/entropy changes could affect backend verification or any strict assumptions about nonce structure.
> 
> **Overview**
> Hardens WalletConnect v2 authentication by replacing the `nonce` generator in `getAuthTokenInfo` from `Math.random()` to a cryptographically strong `crypto.randomUUID()` (dashless) value to reduce replay/predictability risk.
> 
> No functional flow changes beyond nonce generation (plus a minor EOF newline adjustment).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ed5ee8bc7c2a1c81794fc804e5a30f7f0add0af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->