### PR TITLE
fix(no-modal): SIWE nonces via viem and WC redirect logging

### DIFF
--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -37,9 +37,6 @@
     "@solana/react-hooks": {
       "optional": true
     },
-    "viem": {
-      "optional": true
-    },
     "vue": {
       "optional": true
     }

--- a/packages/no-modal/package.json
+++ b/packages/no-modal/package.json
@@ -60,9 +60,6 @@
     "react": {
       "optional": true
     },
-    "viem": {
-      "optional": true
-    },
     "vue": {
       "optional": true
     }

--- a/packages/no-modal/src/connectors/base-evm-connector/baseEvmConnector.ts
+++ b/packages/no-modal/src/connectors/base-evm-connector/baseEvmConnector.ts
@@ -1,5 +1,6 @@
 import { signChallenge } from "@toruslabs/base-controllers";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
+import { generateSiweNonce } from "viem/siwe";
 
 import {
   AuthTokenInfo,
@@ -37,7 +38,7 @@ export abstract class BaseEvmConnector<T> extends BaseConnector<T> {
         address: accounts[0],
         chainId: parseInt(chainId, 16),
         version: "1",
-        nonce: Math.random().toString(36).slice(2),
+        nonce: generateSiweNonce(),
         issuedAt: new Date().toISOString(),
       };
 

--- a/packages/no-modal/src/connectors/base-solana-connector/baseSolanaConnector.ts
+++ b/packages/no-modal/src/connectors/base-solana-connector/baseSolanaConnector.ts
@@ -1,4 +1,5 @@
 import { signChallenge } from "@toruslabs/base-controllers";
+import { generateSiweNonce } from "viem/siwe";
 
 import {
   AuthTokenInfo,
@@ -48,7 +49,7 @@ export abstract class BaseSolanaConnector<T> extends BaseConnector<T> {
         address: accounts[0],
         chainId: parseInt(chainId, 16),
         version: "1",
-        nonce: Math.random().toString(36).slice(2),
+        nonce: generateSiweNonce(),
         issuedAt: new Date().toISOString(),
       };
 

--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
@@ -5,6 +5,7 @@ import { SessionTypes } from "@walletconnect/types";
 import { getSdkError, isValidArray } from "@walletconnect/utils";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
 import deepmerge from "deepmerge";
+import { generateSiweNonce } from "viem/siwe";
 
 import {
   type Analytics,
@@ -308,7 +309,7 @@ class WalletConnectV2Connector extends BaseConnector<void> {
         address: accounts[0],
         chainId: parseInt(chainId, 16),
         version: "1",
-        nonce: Math.random().toString(36).slice(2),
+        nonce: generateSiweNonce(),
         issuedAt: new Date().toISOString(),
       };
 

--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Utils.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Utils.ts
@@ -10,7 +10,7 @@ import { type JRPCRequest, providerErrors, rpcErrors } from "@web3auth/auth";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
 import type { GetCapabilitiesReturnType, SendCallsReturnType, WalletGetCallsStatusReturnType } from "viem";
 
-import { AddEthereumChainConfig, WalletLoginError } from "../../base";
+import { AddEthereumChainConfig, log, WalletLoginError } from "../../base";
 import type { IEthProviderHandlers, MessageParams, TransactionParams, TypedMessageParams } from "../../providers/ethereum-provider";
 import { formatChainId } from "./utils";
 
@@ -46,7 +46,7 @@ export async function sendJrpcRequest<T, U>(signClient: ISignClient, chainId: st
         }
         window.open(parsedUrl.href, "_blank");
       } catch (e) {
-        console.error("Invalid redirect URL", e);
+        log.error("Invalid redirect URL", e);
       }
     }
   }


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

- Use `generateSiweNonce` from `viem/siwe` instead of `Math.random().toString(36).slice(2)` when building SIWE-style login messages in `BaseEvmConnector`, `BaseSolanaConnector`, and `WalletConnectV2Connector`, so nonces match SIWE expectations.
- In `walletConnectV2Utils`, log invalid redirect URL handling with the shared `log` helper instead of `console.error`, and ensure the file ends with a newline.

## How has this been tested?

Not run in this environment. Please run the no-modal package lint/tests locally before merge.

## Screenshots (if appropriate)

N/A (no UI changes).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches SIWE challenge construction in multiple connectors, which can affect wallet authentication if the new nonce format interacts unexpectedly with server-side validation. Logging change is low impact, but reviewers should verify login flows across EVM, Solana, and WalletConnect V2.
> 
> **Overview**
> Updates SIWE-style auth payload construction in `BaseEvmConnector`, `BaseSolanaConnector`, and `WalletConnectV2Connector` to use `viem/siwe`’s `generateSiweNonce()` instead of `Math.random()`, aligning nonce generation with SIWE expectations.
> 
> Cleans up WalletConnect V2 mobile redirect error handling by routing invalid redirect URL failures through the shared `log` helper (and fixes file newline), and removes `viem` from `peerDependenciesMeta` optional declarations in `@web3auth/modal` and `@web3auth/no-modal`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95e0af0f0c0cbc1d9e09e393e2925216ec4532fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->