### PR TITLE
fix(no-modal): add disableAnalytics option

### DIFF
--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -88,6 +88,8 @@ export class Analytics {
   private isSkipped() {
     const dappOrigin = window.location.origin;
 
+    if (!this.enabled) return true;
+
     // skip if the protocol is not http or https
     if (dappOrigin.startsWith("http://")) {
       return true;

--- a/packages/no-modal/src/base/core/IWeb3Auth.ts
+++ b/packages/no-modal/src/base/core/IWeb3Auth.ts
@@ -194,6 +194,12 @@ export interface IWeb3AuthCoreOptions {
    * @defaultValue "connect-and-sign"
    */
   initialAuthenticationMode?: ConnectorInitialAuthenticationModeType;
+
+  /**
+   * Whether to disable analytics
+   * @defaultValue false
+   */
+  disableAnalytics?: boolean;
 }
 
 export type LoginParamMap = {

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -127,6 +127,9 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     this.coreOptions = options;
     this.storage = this.getStorageMethod();
     this.analytics = new Analytics();
+    if (options.disableAnalytics) {
+      this.analytics.disable();
+    }
     this.analytics.setGlobalProperties({ integration_type: ANALYTICS_INTEGRATION_TYPE.NATIVE_SDK });
 
     this.loadState(initialState)


### PR DESCRIPTION
## Summary
- Add `disableAnalytics` option to `IWeb3AuthCoreOptions`.
- Ensure analytics can be disabled early (skips init/track/identify when disabled).

## Test plan
- Build/types: CI
- Manual: instantiate `Web3AuthNoModal` with `{ disableAnalytics: true }` and confirm no Segment calls are made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, opt-in behavior change limited to analytics initialization/telemetry; no auth, key, or transaction logic is affected.
> 
> **Overview**
> Adds a new `disableAnalytics` option to `IWeb3AuthCoreOptions` and wires it into `Web3AuthNoModal` so analytics can be turned off before any initialization or tracking occurs.
> 
> Updates the `Analytics` skip logic to treat the internal `enabled` flag as a first-class gate (in addition to existing origin-based skips), preventing Segment `init`/`identify`/`track` calls when disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54893bd5431161cf714775e73d0699b81ab3c6d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->