### PR TITLE
fix(no-modal): add disableAnalytics option

### DIFF
--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -86,9 +86,8 @@ export class Analytics {
   }
 
   private isSkipped() {
-    const dappOrigin = window.location.origin;
-
     if (!this.enabled) return true;
+    const dappOrigin = window.location.origin;
 
     // skip if the protocol is not http or https
     if (dappOrigin.startsWith("http://")) {

--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -12,6 +12,9 @@ export class Analytics {
   private enabled: boolean = true;
 
   public init(): void {
+    if (!this.enabled) {
+      return;
+    }
     if (this.isSkipped()) {
       return;
     }
@@ -86,10 +89,9 @@ export class Analytics {
   }
 
   private isSkipped() {
-    if (!this.enabled) return true;
     const dappOrigin = window.location.origin;
 
-    // skip if the protocol is not http or https
+    // skip if the protocol is http
     if (dappOrigin.startsWith("http://")) {
       return true;
     }

--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -88,6 +88,8 @@ export class Analytics {
   private isSkipped() {
     const dappOrigin = window.location.origin;
 
+    if (!this.enabled) return true;
+
     // skip if the protocol is not http or https
     if (dappOrigin.startsWith("http://")) {
       return true;

--- a/packages/no-modal/src/base/core/IWeb3Auth.ts
+++ b/packages/no-modal/src/base/core/IWeb3Auth.ts
@@ -188,6 +188,12 @@ export interface IWeb3AuthCoreOptions {
    * @defaultValue "connect-only"
    */
   initialAuthenticationMode?: ConnectorInitialAuthenticationModeType;
+
+  /**
+   * Whether to disable analytics
+   * @defaultValue false
+   */
+  disableAnalytics?: boolean;
 }
 
 export type LoginParamMap = {

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -103,6 +103,9 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     this.coreOptions = options;
     this.storage = this.getStorageMethod();
     this.analytics = new Analytics();
+    if (options.disableAnalytics) {
+      this.analytics.disable();
+    }
     this.analytics.setGlobalProperties({ integration_type: ANALYTICS_INTEGRATION_TYPE.NATIVE_SDK });
 
     this.loadState(initialState);


### PR DESCRIPTION
## Summary
- Add `disableAnalytics` option to `IWeb3AuthCoreOptions`.
- Ensure analytics can be disabled early (skips init/track/identify when disabled).

## Test plan
- Build/types: CI
- Manual: instantiate `Web3AuthNoModal` with `{ disableAnalytics: true }` and confirm no Segment calls are made.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to analytics toggling and initialization flow; primary risk is unintentionally suppressing analytics events when the new flag is set.
> 
> **Overview**
> Adds a new `disableAnalytics` option to `IWeb3AuthCoreOptions` and wires it into `Web3AuthNoModal` so analytics can be turned off at construction time.
> 
> Updates `Analytics.init()` to early-return when disabled, preventing Segment initialization (and by extension downstream `identify`/`track` calls that already no-op when disabled). Also adjusts the skip-condition comment/intent around `http://` origins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0857c051b73458dc9ff70602939fcd0eb80ce014. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->