### PR TITLE
fix: circular import

### DIFF
--- a/packages/modal/src/utils.ts
+++ b/packages/modal/src/utils.ts
@@ -1,4 +1,4 @@
-import { type UIConfig } from "./ui";
+import { type UIConfig } from "./ui/interfaces";
 
 export const getLoginModalAnalyticsProperties = (uiConfig?: UIConfig) => {
   return {

--- a/packages/no-modal/src/base/connector/baseConnector.ts
+++ b/packages/no-modal/src/base/connector/baseConnector.ts
@@ -4,19 +4,18 @@ import type { Wallet } from "@wallet-standard/base";
 import { SafeEventEmitter } from "@web3auth/auth";
 
 import { CHAIN_NAMESPACES, type ChainNamespaceType, CONNECTOR_NAMESPACES, ConnectorNamespaceType, CustomChainConfig } from "../chain/IChainInterface";
+import { type BaseConnectorSettings } from "../core/IWeb3AuthOptions";
 import { WalletInitializationError, WalletLoginError } from "../errors";
 import { log } from "../loglevel";
 import { citadelServerUrl } from "../utils";
 import { WALLET_CONNECTOR_TYPE, WALLET_CONNECTORS } from "../wallet";
 import { CAN_AUTHORIZE_STATUSES, CONNECTED_STATUSES } from "./connectorStatus";
-import { CONNECTOR_EVENTS, CONNECTOR_STATUS } from "./constants";
+import { CONNECTOR_EVENTS, CONNECTOR_STATUS, type CONNECTOR_STATUS_TYPE } from "./constants";
 import type {
   AuthTokenInfo,
   BaseConnectorLoginParams,
-  BaseConnectorSettings,
   Connection,
   CONNECTOR_CATEGORY_TYPE,
-  CONNECTOR_STATUS_TYPE,
   ConnectorEvents,
   ConnectorInitOptions,
   IConnector,

--- a/packages/no-modal/src/base/connector/connectorStatus.ts
+++ b/packages/no-modal/src/base/connector/connectorStatus.ts
@@ -1,5 +1,4 @@
-import { CONNECTOR_STATUS } from "./constants";
-import { CONNECTOR_STATUS_TYPE } from "./interfaces";
+import { CONNECTOR_STATUS, type CONNECTOR_STATUS_TYPE } from "./constants";
 
 export const CONNECTED_STATUSES: CONNECTOR_STATUS_TYPE[] = [CONNECTOR_STATUS.CONNECTED, CONNECTOR_STATUS.AUTHORIZED];
 

--- a/packages/no-modal/src/base/connector/constants.ts
+++ b/packages/no-modal/src/base/connector/constants.ts
@@ -11,6 +11,8 @@ export const CONNECTOR_STATUS = {
   CONSENT_REQUIRING: "consent_requiring",
 } as const;
 
+export type CONNECTOR_STATUS_TYPE = (typeof CONNECTOR_STATUS)[keyof typeof CONNECTOR_STATUS];
+
 export const CONNECTOR_EVENTS = {
   ...CONNECTOR_STATUS,
   CONNECTOR_DATA_UPDATED: "connector_data_updated",

--- a/packages/no-modal/src/base/connector/interfaces.ts
+++ b/packages/no-modal/src/base/connector/interfaces.ts
@@ -15,14 +15,14 @@ import {
   type WEB3AUTH_NETWORK_TYPE,
 } from "@web3auth/auth";
 
-import { type Analytics } from "../analytics";
 import type { ChainNamespaceType, ConnectorNamespaceType, CustomChainConfig } from "../chain/IChainInterface";
-import type { IWeb3AuthCoreOptions } from "../core/IWeb3Auth";
 import { Web3AuthError } from "../errors";
-import type { LoginModeType, ProjectConfig } from "../interfaces";
+import type { LoginModeType } from "../interfaces";
 import type { ProviderEvents, SafeEventEmitterProvider } from "../provider/IProvider";
 import { WALLET_CONNECTOR_TYPE } from "../wallet";
-import { CONNECTOR_CATEGORY, CONNECTOR_EVENTS, CONNECTOR_STATUS } from "./constants";
+import { CONNECTOR_CATEGORY, CONNECTOR_EVENTS, type CONNECTOR_STATUS_TYPE } from "./constants";
+
+export type { CONNECTOR_STATUS_TYPE } from "./constants";
 
 export type UserInfo = AuthUserInfo;
 
@@ -45,14 +45,7 @@ export interface ConnectorInitOptions {
   getAuthTokenInfo?: boolean;
 }
 
-export type CONNECTOR_STATUS_TYPE = (typeof CONNECTOR_STATUS)[keyof typeof CONNECTOR_STATUS];
-
 export type AuthTokenInfo = { idToken: string; accessToken?: string; refreshToken?: string };
-
-export interface BaseConnectorSettings {
-  coreOptions: IWeb3AuthCoreOptions;
-  analytics?: Analytics;
-}
 
 export interface IProvider extends SafeEventEmitter<ProviderEvents> {
   get chainId(): string;
@@ -99,18 +92,10 @@ export interface IConnector<T> extends SafeEventEmitter {
   cleanup?(): Promise<void>;
 }
 
-export type ConnectorParams = {
-  projectConfig?: ProjectConfig;
-  coreOptions: IWeb3AuthCoreOptions;
-  analytics: Analytics;
-};
-
 export type BaseConnectorLoginParams = {
   chainId: string;
   getAuthTokenInfo: boolean;
 };
-
-export type ConnectorFn = (params: ConnectorParams) => IConnector<unknown>;
 
 export type CONNECTED_EVENT_DATA = Connection & {
   reconnected: boolean;

--- a/packages/no-modal/src/base/core/IWeb3Auth.ts
+++ b/packages/no-modal/src/base/core/IWeb3Auth.ts
@@ -1,36 +1,15 @@
-import { type AccountAbstractionMultiChainConfig } from "@toruslabs/ethereum-controllers";
-import {
-  type BUILD_ENV_TYPE,
-  type CookieOptions,
-  type LoginParams,
-  MfaLevelType,
-  MfaSettings,
-  SafeEventEmitter,
-  type StorageConfig,
-  UX_MODE_TYPE,
-  type WhiteLabelData,
-} from "@web3auth/auth";
-import { type WsEmbedParams } from "@web3auth/ws-embed";
+import { type LoginParams, SafeEventEmitter } from "@web3auth/auth";
 
 import { type ChainNamespaceType, type CustomChainConfig } from "../chain/IChainInterface";
-import {
-  type AuthTokenInfo,
-  CONNECTED_EVENT_DATA,
-  type Connection,
-  CONNECTOR_EVENTS,
-  CONNECTOR_INITIAL_AUTHENTICATION_MODE,
-  type CONNECTOR_STATUS_TYPE,
-  ConnectorEvents,
-  type ConnectorFn,
-  type IBaseProvider,
-  type IConnector,
-  type UserInfo,
-  type WEB3AUTH_NETWORK_TYPE,
-} from "../connector";
+import { CONNECTOR_EVENTS, type CONNECTOR_STATUS_TYPE } from "../connector/constants";
+import type { AuthTokenInfo, CONNECTED_EVENT_DATA, Connection, ConnectorEvents, IConnector, UserInfo } from "../connector/interfaces";
 import { Web3AuthError } from "../errors";
 import { LoginModeType } from "../interfaces";
-import { type IPlugin, type PluginFn } from "../plugin";
+import type { IPlugin } from "../plugin/IPlugin";
 import { type WALLET_CONNECTOR_TYPE, WALLET_CONNECTORS } from "../wallet";
+import type { IWeb3AuthCoreOptions } from "./IWeb3AuthOptions";
+
+export * from "./IWeb3AuthOptions";
 
 export type AuthLoginParams = LoginParams & {
   // to maintain backward compatibility
@@ -38,163 +17,6 @@ export type AuthLoginParams = LoginParams & {
 
   idToken?: string;
 };
-
-export type WalletServicesConfig = Omit<
-  WsEmbedParams,
-  "buildEnv" | "enableLogging" | "chainId" | "chains" | "confirmationStrategy" | "accountAbstractionConfig"
-> & {
-  /**
-   * Determines how to show confirmation screens
-   * @defaultValue default
-   *
-   * default & auto-approve
-   * - use auto-approve as default
-   * - if wallet connect request use modal
-   *
-   * modal
-   * - use modal always
-   */
-  confirmationStrategy?: Exclude<WsEmbedParams["confirmationStrategy"], "popup">;
-  modalZIndex?: number;
-};
-
-export interface UIConfig extends WhiteLabelData {
-  /**
-   * UX Mode for the auth connector
-   */
-  uxMode?: UX_MODE_TYPE;
-}
-
-export type ConnectorInitialAuthenticationModeType =
-  (typeof CONNECTOR_INITIAL_AUTHENTICATION_MODE)[keyof typeof CONNECTOR_INITIAL_AUTHENTICATION_MODE];
-
-export interface IWeb3AuthCoreOptions {
-  /**
-   * Client id for web3auth.
-   * You can obtain your client id from the web3auth developer dashboard.
-   * You can set any random string for this on localhost.
-   */
-  clientId: string;
-
-  /**
-   * multiple chain configurations,
-   * only provided chains will be used
-   */
-  chains?: CustomChainConfig[];
-
-  /**
-   * default chain Id to use
-   */
-  defaultChainId?: string;
-
-  /**
-   * setting to true will enable logs
-   *
-   * @defaultValue false
-   */
-  enableLogging?: boolean;
-
-  /**
-   * Custom storage adapters for auth tokens (sessionId, accessToken, refreshToken, idToken).
-   * @defaultValue localStorage-based adapters
-   */
-  storage?: StorageConfig;
-
-  /**
-   * Cookie configuration used when storage adapters are cookie-based.
-   */
-  cookieOptions?: CookieOptions;
-
-  /**
-   * sessionTime (in seconds) for idToken issued by Web3Auth for server side verification.
-   * @defaultValue 7 * 86400
-   *
-   * Note: max value can be 30 days (86400 * 30) and min can be  1 sec (1)
-   */
-  sessionTime?: number;
-
-  /**
-   * Web3Auth Network to use for the session.
-   */
-  web3AuthNetwork: WEB3AUTH_NETWORK_TYPE;
-
-  /**
-   * Uses core-kit key with web3auth provider
-   * @defaultValue false
-   */
-  useSFAKey?: boolean;
-
-  /**
-   * WhiteLabel options for web3auth
-   */
-  uiConfig?: UIConfig;
-
-  /**
-   * Account abstraction config for your chain namespace
-   */
-  accountAbstractionConfig?: AccountAbstractionMultiChainConfig;
-
-  /**
-   * Whether to use AA with external wallet
-   */
-  useAAWithExternalWallet?: boolean;
-
-  /**
-   * Connectors to use
-   */
-  connectors?: ConnectorFn[];
-
-  /**
-   * Plugins to use
-   */
-  plugins?: PluginFn[];
-
-  /**
-   * Whether to enable multi injected provider discovery
-   * @defaultValue true
-   */
-  multiInjectedProviderDiscovery?: boolean;
-
-  /**
-   * Wallet services config
-   */
-  walletServicesConfig?: WalletServicesConfig;
-
-  /**
-   * Private key provider for xrpl cases
-   */
-  privateKeyProvider?: IBaseProvider<string>;
-
-  /**
-   * Whether to enable SSR mode
-   *
-   * @defaultValue false
-   */
-  ssr?: boolean;
-
-  /**
-   * Build environment for Auth connector
-   * @internal
-   * @defaultValue BUILD_ENV.PRODUCTION
-   */
-  authBuildEnv?: BUILD_ENV_TYPE;
-
-  /**
-   * MFA settings for the auth connector
-   */
-  mfaSettings?: MfaSettings;
-
-  /**
-   * MFA level for the auth connector
-   */
-  mfaLevel?: MfaLevelType;
-
-  /**
-   * Initial authentication mode for the auth connector.
-   * @defaultValue "connect-and-sign"
-   */
-  initialAuthenticationMode?: ConnectorInitialAuthenticationModeType;
-}
 
 export type LoginParamMap = {
   [WALLET_CONNECTORS.AUTH]: Partial<AuthLoginParams>;
@@ -246,5 +68,3 @@ export type Web3AuthNoModalEvents = Omit<ConnectorEvents, "connected" | "errored
   [CONNECTOR_EVENTS.ERRORED]: (error: Web3AuthError, loginMode: LoginModeType) => void;
   MODAL_VISIBILITY: (visibility: boolean) => void;
 };
-
-export type Web3AuthNoModalOptions = IWeb3AuthCoreOptions;

--- a/packages/no-modal/src/base/core/IWeb3AuthOptions.ts
+++ b/packages/no-modal/src/base/core/IWeb3AuthOptions.ts
@@ -1,0 +1,191 @@
+import { type AccountAbstractionMultiChainConfig } from "@toruslabs/ethereum-controllers";
+import {
+  type BUILD_ENV_TYPE,
+  type CookieOptions,
+  MfaLevelType,
+  MfaSettings,
+  type StorageConfig,
+  UX_MODE_TYPE,
+  type WEB3AUTH_NETWORK_TYPE,
+  type WhiteLabelData,
+} from "@web3auth/auth";
+import { type WsEmbedParams } from "@web3auth/ws-embed";
+
+import { type Analytics } from "../analytics";
+import type { CustomChainConfig } from "../chain/IChainInterface";
+import { CONNECTOR_INITIAL_AUTHENTICATION_MODE } from "../connector/constants";
+import type { IBaseProvider, IConnector } from "../connector/interfaces";
+import type { ProjectConfig } from "../interfaces";
+import type { PluginFn } from "../plugin/IPlugin";
+
+export interface UIConfig extends WhiteLabelData {
+  /**
+   * UX Mode for the auth connector
+   */
+  uxMode?: UX_MODE_TYPE;
+}
+
+export type WalletServicesConfig = Omit<
+  WsEmbedParams,
+  "buildEnv" | "enableLogging" | "chainId" | "chains" | "confirmationStrategy" | "accountAbstractionConfig"
+> & {
+  /**
+   * Determines how to show confirmation screens
+   * @defaultValue default
+   *
+   * default & auto-approve
+   * - use auto-approve as default
+   * - if wallet connect request use modal
+   *
+   * modal
+   * - use modal always
+   */
+  confirmationStrategy?: Exclude<WsEmbedParams["confirmationStrategy"], "popup">;
+  modalZIndex?: number;
+};
+
+export type ConnectorInitialAuthenticationModeType =
+  (typeof CONNECTOR_INITIAL_AUTHENTICATION_MODE)[keyof typeof CONNECTOR_INITIAL_AUTHENTICATION_MODE];
+
+export interface IWeb3AuthCoreOptions {
+  /**
+   * Client id for web3auth.
+   * You can obtain your client id from the web3auth developer dashboard.
+   * You can set any random string for this on localhost.
+   */
+  clientId: string;
+
+  /**
+   * multiple chain configurations,
+   * only provided chains will be used
+   */
+  chains?: CustomChainConfig[];
+
+  /**
+   * default chain Id to use
+   */
+  defaultChainId?: string;
+
+  /**
+   * setting to true will enable logs
+   *
+   * @defaultValue false
+   */
+  enableLogging?: boolean;
+
+  /**
+   * Custom storage adapters for auth tokens (sessionId, accessToken, refreshToken, idToken).
+   * @defaultValue localStorage-based adapters
+   */
+  storage?: StorageConfig;
+
+  /**
+   * Cookie configuration used when storage adapters are cookie-based.
+   */
+  cookieOptions?: CookieOptions;
+
+  /**
+   * sessionTime (in seconds) for idToken issued by Web3Auth for server side verification.
+   * @defaultValue 7 * 86400
+   *
+   * Note: max value can be 30 days (86400 * 30) and min can be  1 sec (1)
+   */
+  sessionTime?: number;
+
+  /**
+   * Web3Auth Network to use for the session.
+   */
+  web3AuthNetwork: WEB3AUTH_NETWORK_TYPE;
+
+  /**
+   * Uses core-kit key with web3auth provider
+   * @defaultValue false
+   */
+  useSFAKey?: boolean;
+
+  /**
+   * WhiteLabel options for web3auth
+   */
+  uiConfig?: UIConfig;
+
+  /**
+   * Account abstraction config for your chain namespace
+   */
+  accountAbstractionConfig?: AccountAbstractionMultiChainConfig;
+
+  /**
+   * Whether to use AA with external wallet
+   */
+  useAAWithExternalWallet?: boolean;
+
+  /**
+   * Connectors to use
+   */
+  connectors?: ConnectorFn[];
+
+  /**
+   * Plugins to use
+   */
+  plugins?: PluginFn[];
+
+  /**
+   * Whether to enable multi injected provider discovery
+   * @defaultValue true
+   */
+  multiInjectedProviderDiscovery?: boolean;
+
+  /**
+   * Wallet services config
+   */
+  walletServicesConfig?: WalletServicesConfig;
+
+  /**
+   * Private key provider for xrpl cases
+   */
+  privateKeyProvider?: IBaseProvider<string>;
+
+  /**
+   * Whether to enable SSR mode
+   *
+   * @defaultValue false
+   */
+  ssr?: boolean;
+
+  /**
+   * Build environment for Auth connector
+   * @internal
+   * @defaultValue BUILD_ENV.PRODUCTION
+   */
+  authBuildEnv?: BUILD_ENV_TYPE;
+
+  /**
+   * MFA settings for the auth connector
+   */
+  mfaSettings?: MfaSettings;
+
+  /**
+   * MFA level for the auth connector
+   */
+  mfaLevel?: MfaLevelType;
+
+  /**
+   * Initial authentication mode for the auth connector.
+   * @defaultValue "connect-and-sign"
+   */
+  initialAuthenticationMode?: ConnectorInitialAuthenticationModeType;
+}
+
+export interface BaseConnectorSettings {
+  coreOptions: IWeb3AuthCoreOptions;
+  analytics?: Analytics;
+}
+
+export type ConnectorParams = {
+  projectConfig?: ProjectConfig;
+  coreOptions: IWeb3AuthCoreOptions;
+  analytics: Analytics;
+};
+
+export type ConnectorFn = (params: ConnectorParams) => IConnector<unknown>;
+
+export type Web3AuthNoModalOptions = IWeb3AuthCoreOptions;

--- a/packages/no-modal/src/base/plugin/IPlugin.ts
+++ b/packages/no-modal/src/base/plugin/IPlugin.ts
@@ -1,8 +1,9 @@
 import { type SafeEventEmitter, WhiteLabelData } from "@web3auth/auth";
 
 import { type Analytics } from "../analytics";
-import { CHAIN_NAMESPACES } from "../chain/IChainInterface";
-import { type IWeb3AuthCore } from "../core/IWeb3Auth";
+import { CHAIN_NAMESPACES, type CustomChainConfig } from "../chain/IChainInterface";
+import type { CONNECTOR_STATUS_TYPE } from "../connector/constants";
+import type { Connection, IConnector } from "../connector/interfaces";
 import { type WALLET_CONNECTOR_TYPE } from "../wallet";
 
 export const PLUGIN_NAMESPACES = {
@@ -39,12 +40,20 @@ export const WALLET_PLUGINS = {
   ...SOLANA_PLUGINS,
 } as const;
 
+export interface IWeb3AuthPluginHost {
+  currentChain: CustomChainConfig | undefined;
+  connectedConnectorName: WALLET_CONNECTOR_TYPE | null;
+  status: CONNECTOR_STATUS_TYPE;
+  connection: Connection | null;
+  getConnector(connectorName: WALLET_CONNECTOR_TYPE): IConnector<unknown> | null;
+}
+
 export interface IPlugin extends SafeEventEmitter {
   name: string;
   status: PLUGIN_STATUS_TYPE;
   SUPPORTED_CONNECTORS: WALLET_CONNECTOR_TYPE[];
   pluginNamespace: PluginNamespace;
-  initWithWeb3Auth(web3auth: IWeb3AuthCore, whiteLabel?: WhiteLabelData, analytics?: Analytics): Promise<void>;
+  initWithWeb3Auth(web3auth: IWeb3AuthPluginHost, whiteLabel?: WhiteLabelData, analytics?: Analytics): Promise<void>;
   connect(): Promise<void>;
   disconnect(): Promise<void>;
   cleanup(): Promise<void>;

--- a/packages/no-modal/src/base/utils.ts
+++ b/packages/no-modal/src/base/utils.ts
@@ -2,13 +2,12 @@ import { CHAIN_NAMESPACES, cloneDeep } from "@toruslabs/base-controllers";
 import { CITADEL_SERVER_MAP, DASHBOARD_PUBLIC_API_MAP } from "@toruslabs/constants";
 import { type AccountAbstractionMultiChainConfig } from "@toruslabs/ethereum-controllers";
 import { get } from "@toruslabs/http-helpers";
-import { BUILD_ENV, type BUILD_ENV_TYPE } from "@web3auth/auth";
+import { BUILD_ENV, type BUILD_ENV_TYPE, type WEB3AUTH_NETWORK_TYPE } from "@web3auth/auth";
 import { type Chain } from "viem";
 
 import { type CustomChainConfig } from "./chain/IChainInterface";
-import { type WEB3AUTH_NETWORK_TYPE } from "./connector";
 import { SOLANA_CAIP_CHAIN_MAP, WALLET_REGISTRY_URL } from "./constants";
-import { type UIConfig, type WalletServicesConfig } from "./core/IWeb3Auth";
+import { type UIConfig, type WalletServicesConfig } from "./core/IWeb3AuthOptions";
 import { Web3AuthError } from "./errors";
 import type { ProjectConfig, WalletRegistry } from "./interfaces";
 

--- a/packages/no-modal/src/plugins/wallet-services-plugin/plugin.ts
+++ b/packages/no-modal/src/plugins/wallet-services-plugin/plugin.ts
@@ -10,7 +10,7 @@ import {
   ChainNamespaceType,
   EVM_PLUGINS,
   IPlugin,
-  IWeb3AuthCore,
+  type IWeb3AuthPluginHost,
   log,
   PLUGIN_EVENTS,
   PLUGIN_NAMESPACES,
@@ -36,13 +36,13 @@ class WalletServicesPlugin extends SafeEventEmitter implements IPlugin {
 
   public wsEmbedInstance: WsEmbed;
 
-  private web3auth: IWeb3AuthCore | null = null;
+  private web3auth: IWeb3AuthPluginHost | null = null;
 
   private isInitialized = false;
 
   private analytics?: Analytics;
 
-  async initWithWeb3Auth(web3auth: IWeb3AuthCore, _whiteLabel?: WhiteLabelData, analytics?: Analytics): Promise<void> {
+  async initWithWeb3Auth(web3auth: IWeb3AuthPluginHost, _whiteLabel?: WhiteLabelData, analytics?: Analytics): Promise<void> {
     if (this.isInitialized) return;
     if (!web3auth) throw WalletServicesPluginError.web3authRequired();
     if (web3auth.connection && !this.SUPPORTED_CONNECTORS.includes(web3auth.connectedConnectorName)) throw WalletServicesPluginError.notInitialized();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Jira Link:


## Description
<!--- Describe your changes in detail -->

This PR removes several module cycles that showed up when importing through barrels (ui/index, connector/index, plugin/index). Runtime behavior is unchanged; the work is dependency-graph hygiene plus a tighter plugin contract.

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] My code requires a db migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type/export refactor to eliminate circular dependencies, but it touches public interfaces (`IWeb3AuthCoreOptions`, connector status types, plugin host contract) and could cause downstream compile/import breakage.
> 
> **Overview**
> Removes several barrel-induced circular imports by **moving shared option/type definitions into dedicated modules** and updating imports across `modal` and `no-modal`.
> 
> In `no-modal`, `IWeb3AuthCoreOptions`/connector factory settings are extracted to new `base/core/IWeb3AuthOptions.ts`, `CONNECTOR_STATUS_TYPE` is defined/exported from `connector/constants.ts` (instead of `interfaces.ts`), and plugins now depend on a narrower `IWeb3AuthPluginHost` contract rather than the full `IWeb3AuthCore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5be2be860c3b3e52b7c3e3f39650c78c477c431e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->