### PR TITLE
fix: correct no modal skip consent event

### DIFF
--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -234,14 +234,18 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
       };
 
       const handleConsentAccepted = async () => {
-        // track connection completed event
-        const userInfo = await this.getUserInfo();
-        // TODO: correct event data
-        this.analytics.track(ANALYTICS_EVENTS.CONNECTION_COMPLETED, {
-          connector: this.primaryConnector.name,
-          is_mfa_enabled: userInfo?.isMfaEnabled,
-          duration: Date.now() - startTime,
-        });
+        try {
+          // track connection completed event
+          const userInfo = await this.getUserInfo();
+          // TODO: correct event data
+          this.analytics.track(ANALYTICS_EVENTS.CONNECTION_COMPLETED, {
+            connector: this.primaryConnector?.name,
+            is_mfa_enabled: userInfo?.isMfaEnabled,
+            duration: Date.now() - startTime,
+          });
+        } catch (error) {
+          log.error("Failed to track connection completed event after consent acceptance", error);
+        }
 
         handleCompletion();
       };

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -218,6 +218,8 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
     if (CONNECTED_STATUSES.includes(this.status) && this.connection) return this.connection;
     this.loginModal.open();
     return new Promise((resolve, reject) => {
+      // track connection started event
+      const startTime = Date.now();
       // remove all listeners when promise is resolved or rejected.
       // this is to prevent memory leaks if user clicks connect button multiple times.
       const handleCompletion = () => {
@@ -229,6 +231,19 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
           this.removeListener(CONNECTOR_EVENTS.CONNECTED, handleCompletion);
         }
         return resolve(this.connection);
+      };
+
+      const handleConsentAccepted = async () => {
+        // track connection completed event
+        const userInfo = await this.getUserInfo();
+        // TODO: correct event data
+        this.analytics.track(ANALYTICS_EVENTS.CONNECTION_COMPLETED, {
+          connector: this.primaryConnector.name,
+          is_mfa_enabled: userInfo?.isMfaEnabled,
+          duration: Date.now() - startTime,
+        });
+
+        handleCompletion();
       };
 
       const handleError = (err: unknown) => {
@@ -249,7 +264,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
       };
 
       if (this.consentRequired) {
-        this.once(CONNECTOR_EVENTS.CONSENT_ACCEPTED, handleCompletion);
+        this.once(CONNECTOR_EVENTS.CONSENT_ACCEPTED, handleConsentAccepted);
       }
       if (this.coreOptions.initialAuthenticationMode === CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN) {
         this.once(CONNECTOR_EVENTS.AUTHORIZED, handleCompletion);

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -412,7 +412,6 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
         this.removeListener(CONNECTOR_EVENTS.CONNECTED, onConnected);
         this.removeListener(CONNECTOR_EVENTS.ERRORED, onErrored);
         this.removeListener(CONNECTOR_EVENTS.AUTHORIZED, onAuthorized);
-        this.removeListener(CONNECTOR_EVENTS.CONSENT_ACCEPTED, onConsentAccepted);
       };
 
       const checkCompletion = async () => {
@@ -453,10 +452,6 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
         await checkCompletion();
       };
 
-      const onConsentAccepted = async () => {
-        await completeConnection();
-      };
-
       const onErrored = async (err: Web3AuthError) => {
         // track connection failed event
         this.analytics.track(ANALYTICS_EVENTS.CONNECTION_FAILED, {
@@ -471,9 +466,6 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       this.once(CONNECTOR_EVENTS.CONNECTED, onConnected);
       if (finalLoginParams.getAuthTokenInfo) {
         this.once(CONNECTOR_EVENTS.AUTHORIZED, onAuthorized);
-      }
-      if (this.consentRequired) {
-        this.once(CONNECTOR_EVENTS.CONSENT_ACCEPTED, onConsentAccepted);
       }
       this.once(CONNECTOR_EVENTS.ERRORED, onErrored);
       connector.connect(finalLoginParams);

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -286,20 +286,8 @@ describe("Web3AuthNoModal", () => {
     const ethereumProvider = { request: vi.fn().mockResolvedValue(["0xAbC123"]) };
     const authorizedListener = vi.fn();
     sdk.on(CONNECTOR_EVENTS.AUTHORIZED, authorizedListener);
-    const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK } as never);
-    (sdk as unknown as { connectors: MockConnector[] }).connectors = [connector];
-    sdk.exposeSubscribeToConnectorEvents(connector);
-    (sdk as unknown as { commonJRPCProvider: Record<string, unknown> }).commonJRPCProvider = {
-      updateProviderEngineProxy: vi.fn(),
-      removeAllListeners: vi.fn(),
-    };
 
-    connector.emit(CONNECTOR_EVENTS.CONNECTED, {
-      connectorName: WALLET_CONNECTORS.METAMASK,
-      ethereumProvider: ethereumProvider as never,
-      solanaWallet: null,
-      reconnected: false,
-    });
+    const connector = emitMetaMaskConnected(sdk, ethereumProvider);
     await vi.waitFor(() => {
       expect(sdk.status).toBe(CONNECTOR_STATUS.CONNECTED);
     });
@@ -328,29 +316,15 @@ describe("Web3AuthNoModal", () => {
     sdk.on(CONNECTOR_EVENTS.CONSENT_REQUIRING, consentRequiredListener);
 
     const ethereumProvider = { request: vi.fn().mockResolvedValue(["0xBEEF"]) };
-    const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK } as never);
-    connector.connect = vi.fn(async () => {
-      connector.emit(CONNECTOR_EVENTS.CONNECTED, {
-        connectorName: WALLET_CONNECTORS.METAMASK,
-        ethereumProvider: ethereumProvider as never,
-        solanaWallet: null,
-        reconnected: false,
-      });
-      return null;
-    });
-    (sdk as unknown as { connectors: MockConnector[] }).connectors = [connector];
-    sdk.exposeSubscribeToConnectorEvents(connector);
-    (sdk as unknown as { commonJRPCProvider: Record<string, unknown> }).commonJRPCProvider = {
-      updateProviderEngineProxy: vi.fn(),
-      removeAllListeners: vi.fn(),
-    };
 
-    const connectionPromise = sdk.connectTo(WALLET_CONNECTORS.METAMASK);
+    emitMetaMaskConnected(sdk, ethereumProvider);
     await vi.waitFor(() => {
       expect(consentRequiredListener).toHaveBeenCalledTimes(1);
     });
+
+    expect(sdk.status).toBe(CONNECTOR_STATUS.CONSENT_REQUIRING);
     await sdk.exposeCompleteConsentAcceptance();
-    await expect(connectionPromise).resolves.not.toBeNull();
+    expect(sdk.status).toBe(CONNECTOR_STATUS.CONNECTED);
   });
 
   it("persists user consent when user accepts consent UI", async () => {
@@ -364,29 +338,12 @@ describe("Web3AuthNoModal", () => {
     const consentRequiredListener = vi.fn();
     sdk.on(CONNECTOR_EVENTS.CONSENT_REQUIRING, consentRequiredListener);
     const ethereumProvider = { request: vi.fn().mockResolvedValue(["0xFEEd"]) };
-    const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK } as never);
-    connector.connect = vi.fn(async () => {
-      connector.emit(CONNECTOR_EVENTS.CONNECTED, {
-        connectorName: WALLET_CONNECTORS.METAMASK,
-        ethereumProvider: ethereumProvider as never,
-        solanaWallet: null,
-        reconnected: false,
-      });
-      return null;
-    });
-    (sdk as unknown as { connectors: MockConnector[] }).connectors = [connector];
-    sdk.exposeSubscribeToConnectorEvents(connector);
-    (sdk as unknown as { commonJRPCProvider: Record<string, unknown> }).commonJRPCProvider = {
-      updateProviderEngineProxy: vi.fn(),
-      removeAllListeners: vi.fn(),
-    };
 
-    const connectionPromise = sdk.connectTo(WALLET_CONNECTORS.METAMASK);
+    emitMetaMaskConnected(sdk, ethereumProvider);
     await vi.waitFor(() => {
       expect(consentRequiredListener).toHaveBeenCalledTimes(1);
     });
     await sdk.exposeCompleteConsentAcceptance();
-    await connectionPromise;
 
     const stateJson = await storage.get(WEB3AUTH_STATE_STORAGE_KEY);
     const state = JSON.parse(stateJson!);
@@ -434,16 +391,36 @@ describe("Web3AuthNoModal", () => {
   });
 });
 
-function createSdk(overrides: Record<string, unknown> = {}, initialState?: Record<string, unknown>) {
+function createSdk(overrides: Record<string, unknown> = {}, initialState?: Record<string, unknown>): TestWeb3AuthNoModal {
   const storage = createMockStorage();
   return new TestWeb3AuthNoModal(
     {
       clientId: "test-client-id",
       web3AuthNetwork: "sapphire_devnet",
       chains: [createChain()],
+      disableAnalytics: true,
       storage: { sessionId: storage },
       ...overrides,
     } as never,
     initialState as never
   );
+}
+
+function emitMetaMaskConnected(sdk: TestWeb3AuthNoModal, ethereumProvider: unknown): MockConnector {
+  const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK } as never);
+  (sdk as unknown as { connectors: MockConnector[] }).connectors = [connector];
+  sdk.exposeSubscribeToConnectorEvents(connector);
+  (sdk as unknown as { commonJRPCProvider: Record<string, unknown> }).commonJRPCProvider = {
+    updateProviderEngineProxy: vi.fn(),
+    removeAllListeners: vi.fn(),
+  };
+
+  connector.emit(CONNECTOR_EVENTS.CONNECTED, {
+    connectorName: WALLET_CONNECTORS.METAMASK,
+    ethereumProvider: ethereumProvider as never,
+    solanaWallet: null,
+    reconnected: false,
+  });
+
+  return connector;
 }


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->

Previously we need to update/persist the consent state which is only available in the no-modal, CONSENT is only available for modal and we already have the listener from modalManager. Otherwise, we will need to have two different state management for modal and no-modal to manage the consent state.
This PR remove the consent event listening in no modal which was incorrectly added.

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk behavior cleanup focused on consent gating: `no-modal` no longer incorrectly waits for `CONSENT_ACCEPTED`, while `modal` adds analytics tracking after consent acceptance. Changes are localized to connection event listeners and test updates.
> 
> **Overview**
> Aligns consent handling between SDK modes: **`no-modal` connection no longer listens for `CONNECTOR_EVENTS.CONSENT_ACCEPTED`** (preventing connection completion from being incorrectly gated on that event).
> 
> In the modal SDK, `connect()` now **tracks `ANALYTICS_EVENTS.CONNECTION_COMPLETED` after consent is accepted**, including duration and basic connector/user MFA properties.
> 
> Tests are updated to reflect the new flow, including a small helper (`emitMetaMaskConnected`) and disabling analytics in the no-modal test SDK setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72ab04c3e63d318ceda4bf4c7cb9949a1127d72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->