### PR TITLE
Use same consent config with sdk and whitelabel

### DIFF
--- a/demo/vue-app-new/src/MainView.vue
+++ b/demo/vue-app-new/src/MainView.vue
@@ -131,9 +131,10 @@ const options = computed((): Web3AuthOptions => {
     ? { ...whiteLabel, widgetType: widget, targetId, hideSuccessScreen, ...(externalWalletOnly && { primaryButton: "externalLogin" }) }
     : { widgetType: widget, targetId, hideSuccessScreen, ...(externalWalletOnly && { primaryButton: "externalLogin" }) };
   if (consentConfigMode === "required") {
-    uiConfig.consentConfig = {
-      required: true,
-    };
+    uiConfig.consentRequired = true;
+    // required links to make the consent required work
+    uiConfig.privacyPolicy = "https://web3auth.io/privacy";
+    uiConfig.tncLink = "https://web3auth.io/terms";
   }
   const authConnectorInstance = authConnector({ connectorSettings: {} });
 

--- a/demo/wagmi-react-app/src/App.tsx
+++ b/demo/wagmi-react-app/src/App.tsx
@@ -55,9 +55,9 @@ function App() {
     };
 
     if (consentConfigMode === "required") {
-      web3AuthOptions.uiConfig = {
-        consentConfig,
-      };
+      web3AuthOptions.uiConfig!.consentRequired = true;
+      web3AuthOptions.uiConfig!.privacyPolicy = consentConfig.privacyPolicy;
+      web3AuthOptions.uiConfig!.tncLink = consentConfig.tncLink;
     }
 
     return { web3AuthOptions };

--- a/demo/wagmi-react-app/src/App.tsx
+++ b/demo/wagmi-react-app/src/App.tsx
@@ -34,12 +34,6 @@ const chains: Web3AuthContextConfig["web3AuthOptions"]["chains"] = [
   },
 ];
 
-const consentConfig = {
-  required: true,
-  privacyPolicy: "https://example.com/privacy",
-  tncLink: "https://example.com/terms",
-};
-
 type ConsentConfigMode = "disabled" | "required";
 
 function App() {
@@ -55,9 +49,11 @@ function App() {
     };
 
     if (consentConfigMode === "required") {
-      web3AuthOptions.uiConfig!.consentRequired = true;
-      web3AuthOptions.uiConfig!.privacyPolicy = consentConfig.privacyPolicy;
-      web3AuthOptions.uiConfig!.tncLink = consentConfig.tncLink;
+      web3AuthOptions.uiConfig = {
+        consentRequired: true,
+        privacyPolicy: "https://example.com/privacy",
+        tncLink: "https://example.com/terms",
+      };
     }
 
     return { web3AuthOptions };

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -73,7 +73,9 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
 
     if (!this.options.uiConfig) this.options.uiConfig = {};
     if (this.options.modalConfig) this.modalConfig = this.options.modalConfig;
-    this.consentRequired = this.options.uiConfig.consentConfig?.required || false;
+    // consent required is true if the consent required is true and the privacy policy and tnc link are set
+    this.consentRequired =
+      (this.options.uiConfig.consentRequired && Boolean(this.options.uiConfig.privacyPolicy) && Boolean(this.options.uiConfig.tncLink)) || false;
 
     log.info("modalConfig", this.modalConfig);
   }
@@ -137,7 +139,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
           onDeclineConsent: this.onDeclineConsent,
         }
       );
-      this.consentRequired = this.options.uiConfig.consentConfig?.required || false;
+      this.consentRequired = this.loginModal.consentRequired;
       await withAbort(() => this.loginModal.initModal(), signal);
 
       // setup common JRPC provider

--- a/packages/modal/src/ui/components/Loader/Loader.tsx
+++ b/packages/modal/src/ui/components/Loader/Loader.tsx
@@ -188,7 +188,7 @@ function ConsentRequiredStatus(props: {
           type="button"
           disabled={isSubmitting}
           onClick={handleAccept}
-          className="w3a--btn wta:rounded-full wta:border-app-primary-600 wta:bg-app-primary-600 wta:hover:border-app-primary-700 wta:hover:bg-app-primary-700 wta:disabled:opacity-60 wta:dark:border-app-primary-600 wta:dark:bg-app-primary-600 wta:dark:hover:border-app-primary-700 wta:dark:hover:bg-app-primary-700"
+          className="w3a--btn wta:rounded-full wta:border-app-primary-600! wta:bg-app-primary-600 wta:hover:border-app-primary-700! wta:hover:bg-app-primary-700! wta:disabled:opacity-60 wta:dark:border-app-primary-600! wta:dark:bg-app-primary-600 wta:dark:hover:border-app-primary-700! wta:dark:hover:bg-app-primary-700!"
         >
           <p className="wta:text-app-onPrimary">{t("modal.consent.accept", { defaultValue: "Accept" })}</p>
         </button>

--- a/packages/modal/src/ui/interfaces.ts
+++ b/packages/modal/src/ui/interfaces.ts
@@ -76,15 +76,6 @@ export interface UIConfig extends CoreUIConfig, LoginModalConfig {
   hideSuccessScreen?: boolean;
 
   connectorListener: SafeEventEmitter<Web3AuthNoModalEvents>;
-
-  /**
-   * Config for consent required.
-   *
-   * @defaultValue `undefined`
-   */
-  consentConfig?: {
-    required: boolean;
-  };
 }
 
 export type ModalLoginParams = Pick<

--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -118,7 +118,8 @@ export class LoginModal {
   }
 
   get consentRequired(): boolean {
-    return this.uiConfig.consentConfig?.required || false;
+    // consent required is true if the consent required is true and the privacy policy and tnc link are set
+    return (this.uiConfig.consentRequired && Boolean(this.uiConfig.privacyPolicy) && Boolean(this.uiConfig.tncLink)) || false;
   }
 
   get isDark(): boolean {

--- a/packages/modal/test/modalManager.test.ts
+++ b/packages/modal/test/modalManager.test.ts
@@ -133,7 +133,7 @@ describe("Web3Auth (modal)", () => {
   it("connect resolves on CONSENT_ACCEPTED when consent is required", async () => {
     const sdk = createSdk({
       uiConfig: {
-        consentConfig: { required: true },
+        consentRequired: true,
         privacyPolicy: "https://example.com/privacy",
         tncLink: "https://example.com/terms",
       } as never,


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description
Sdk config for consent required is not the same with whitelabel config (which configurable on dashboard also)

- fix demo: if consent required we add sample links for privacy and tnc (links should be showing on consent screen now)
- fixed some logic on consentRequired (it can only be true if privacy and tnc links are also provided)
- fixed primary button hover effect for accept consent UI

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)
Privacy and Terms links are showing now
<img width="406" height="488" alt="Screenshot 2026-05-07 at 12 13 34 PM" src="https://github.com/user-attachments/assets/f43357e0-f29f-4ba4-925b-45af0812421b" />

Hover effects on accept button is fixed as well
<img width="402" height="485" alt="Screenshot 2026-05-07 at 12 14 32 PM" src="https://github.com/user-attachments/assets/3c63a2dd-7a2d-418c-8766-60f968d0b134" />
<img width="410" height="491" alt="Screenshot 2026-05-07 at 12 14 18 PM" src="https://github.com/user-attachments/assets/150f3d44-1fa2-4ecf-a98a-9ab2c4d0f84c" />


<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public consent configuration shape and the runtime gating for consent, which could break apps still using the old `uiConfig.consentConfig` or expecting consent to trigger without policy/terms links.
> 
> **Overview**
> Unifies “consent required” configuration by removing `uiConfig.consentConfig` and switching to top-level `uiConfig.consentRequired` plus `privacyPolicy`/`tncLink` across the modal SDK and demo apps.
> 
> Tightens consent behavior so consent is only treated as required when **both** `consentRequired` is true *and* `privacyPolicy`/`tncLink` are provided, and updates `Web3Auth`/`LoginModal` to derive `consentRequired` from the modal instance during `init`.
> 
> Includes a small UI tweak to the consent accept button hover/border styling and updates tests to match the new config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d61377058ed26f71b9a845dccdc020d5dbeaac2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->