### PR TITLE
Avoid logging account addresses

### DIFF
--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/utils.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/utils.ts
@@ -3,7 +3,7 @@ import { JRPCRequest, providerErrors } from "@web3auth/auth";
 import { Chain, createWalletClient, Hex, http } from "viem";
 import { BundlerClient, SendUserOperationParameters, SmartAccount } from "viem/account-abstraction";
 
-import { IProvider, log } from "../../../base";
+import { IProvider } from "../../../base";
 import { IEthProviderHandlers, MessageParams, SignTypedDataMessageV4, TransactionParams, TypedMessageParams } from "../../ethereum-provider";
 
 export function getProviderHandlers({
@@ -29,8 +29,6 @@ export function getProviderHandlers({
         smartAccount.getAddress(),
         eoaProvider.request<never, string[]>({ method: "eth_accounts" }),
       ]);
-      log.info("smartAccounts", smartAccounts);
-      log.info("eoaAccounts", eoaAccounts);
       return [smartAccounts, ...eoaAccounts];
     },
     getPrivateKey: async (_: JRPCRequest<unknown>) => {


### PR DESCRIPTION
Removes two non-essential account logs from the account-abstraction provider `getAccounts` handler.

The returned account list is unchanged; the handler just stops printing smart account and EOA addresses to application logs.

Verification:
- `npx prettier --check packages/no-modal/src/providers/account-abstraction-provider/providers/utils.ts`
- `npx tsc -p packages/no-modal/tsconfig.build.json --noEmit`
- `git diff --check`

Related to #2434.