### PR TITLE
fix: fixed wagmi accountsChanged handler during cross namespace switch

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -50,13 +50,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.8.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.0",
-        "@web3auth/no-modal": "^11.0.0-beta.1",
+        "@web3auth/no-modal": "^11.0.0-beta.2",
         "@web3auth/ws-embed": "^6.0.4",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",
@@ -134,7 +134,7 @@
     },
     "../../packages/no-modal": {
       "name": "@web3auth/no-modal",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@metamask/connect-evm": "^1.3.0",

--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -33,12 +33,15 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const { disconnect } = useWeb3AuthDisconnect();
   const wagmiConfig = useWagmiConfig();
   const { mutate: reconnect } = useReconnect();
+  const suppressWagmiDisconnect = useRef(false);
   const lastSyncedWeb3AuthConnection = useRef<unknown>(null);
 
   useConnectionEffect({
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
-      if (isConnected) await disconnect();
+      const isSuppressed = suppressWagmiDisconnect.current;
+      suppressWagmiDisconnect.current = false;
+      if (!isSuppressed && isConnected) await disconnect();
 
       // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
       // from the connected provider
@@ -78,8 +81,11 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         }
       } else if (!isConnected || chainNamespace !== CHAIN_NAMESPACES.EIP155) {
         lastSyncedWeb3AuthConnection.current = null;
-        if (w3aWagmiConnector || wagmiConfig.state.status === "connected") {
+        if (wagmiConfig.state.status === "connected") {
+          suppressWagmiDisconnect.current = true;
           await disconnectWeb3AuthFromWagmi(wagmiConfig);
+        } else if (w3aWagmiConnector) {
+          resetConnectorState(wagmiConfig);
         }
       }
     })();

--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -62,7 +62,7 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         Boolean(newConnection && newEth) &&
         newConnection?.connectorName === primaryConnectorName;
 
-      if (shouldBindToWagmi && newConnection && newEth) {
+      if (shouldBindToWagmi) {
         // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
         // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
         if (lastSyncedWeb3AuthConnection.current !== newConnection) {

--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -67,7 +67,7 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
             resetConnectorState(wagmiConfig);
           }
           lastSyncedWeb3AuthConnection.current = newConnection;
-          const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
+          const connector = setupConnector(newEth, wagmiConfig);
           if (!connector) {
             log.error("Failed to setup react wagmi connector");
             throw new Error("Failed to setup connector");

--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -1,26 +1,28 @@
 import { CHAIN_NAMESPACES, type CustomChainConfig, log, WalletInitializationError } from "@web3auth/no-modal";
-import { createElement, Fragment, PropsWithChildren, useCallback, useEffect, useMemo, useRef } from "react";
-import { type Chain, defineChain, http, isAddress as isValidEvmAddress, webSocket } from "viem";
 import {
-  Connection,
-  Connector,
+  connectWeb3AuthWithWagmi,
+  disconnectWeb3AuthFromWagmi,
+  getWeb3authConnector,
+  resetConnectorState,
+  setupConnector,
+} from "@web3auth/no-modal/react/wagmi";
+import { createElement, Fragment, PropsWithChildren, useEffect, useMemo, useRef } from "react";
+import { type Chain, defineChain, http, webSocket } from "viem";
+import {
   createConfig as createWagmiConfig,
   type CreateConfigParameters,
-  CreateConnectorFn,
   fallback,
   useConfig as useWagmiConfig,
   useConnectionEffect,
   useReconnect,
   WagmiProvider as WagmiProviderBase,
 } from "wagmi";
-import { injected } from "wagmi/connectors";
 
 import { useWeb3Auth, useWeb3AuthDisconnect } from "../hooks";
 import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
-const WEB3AUTH_CONNECTOR_ID = "web3auth";
-
+// TODO: re-use the provider from the no-modal package
 function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const {
     isConnected,
@@ -33,112 +35,6 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const { mutate: reconnect } = useReconnect();
   const lastSyncedWeb3AuthConnection = useRef<unknown>(null);
 
-  const web3authConnector = useMemo(() => {
-    return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-  }, [wagmiConfig]);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const createWeb3AuthConnector = useCallback((provider: any): CreateConnectorFn => {
-    const baseConnector = injected({
-      target: {
-        provider: provider,
-        id: WEB3AUTH_CONNECTOR_ID,
-        name: "Web3Auth",
-      },
-    });
-
-    return (config) => {
-      const connector = baseConnector(config);
-      const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
-
-      // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
-      // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
-      // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
-      connector.onAccountsChanged = (accounts: string[]) => {
-        if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isValidEvmAddress(account))) {
-          log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
-          return;
-        }
-        baseOnAccountsChanged(accounts);
-      };
-
-      return connector;
-    };
-  }, []);
-
-  // to initialize connectors for the given wallets
-  const setupConnector = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (provider: any) => {
-      if (web3authConnector) return web3authConnector;
-
-      // Create new connector if not already existing
-      const connector = createWeb3AuthConnector(provider);
-
-      const result = wagmiConfig._internal.connectors.setup(connector);
-      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
-      return result;
-    },
-    [wagmiConfig, web3authConnector, createWeb3AuthConnector]
-  );
-
-  // to connect a wallet and update wagmi state
-  const connectWeb3AuthWithWagmi = useCallback(
-    async (connector: Connector) => {
-      await Promise.all([
-        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
-        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
-      ]);
-
-      let chainId = await connector.getChainId();
-      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
-        chainId = wagmiConfig.chains[0].id;
-      }
-
-      const accounts = await connector.getAccounts();
-
-      const connections: Map<string, Connection> = new Map([
-        [
-          connector.uid,
-          {
-            accounts: [accounts[0]],
-            chainId,
-            connector,
-          },
-        ],
-      ]);
-
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId,
-        connections,
-        current: connector.uid,
-        status: "connected",
-      }));
-    },
-    [wagmiConfig]
-  );
-
-  const resetConnectorState = useCallback(() => {
-    wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-    wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-  }, [wagmiConfig]);
-
-  const disconnectWeb3AuthFromWagmi = useCallback(async () => {
-    await Promise.all([
-      wagmiConfig.storage?.setItem(`${web3authConnector?.id}.disconnected`, true),
-      wagmiConfig.storage?.removeItem("injected.connected"),
-    ]);
-    resetConnectorState();
-    wagmiConfig.setState((state) => ({
-      ...state,
-      chainId: state.chainId,
-      connections: new Map(),
-      current: undefined,
-      status: "disconnected",
-    }));
-  }, [wagmiConfig, web3authConnector, resetConnectorState]);
-
   useConnectionEffect({
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
@@ -146,8 +42,8 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
 
       // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
       // from the connected provider
-      if (web3authConnector) {
-        resetConnectorState();
+      if (getWeb3authConnector(wagmiConfig)) {
+        resetConnectorState(wagmiConfig);
       }
     },
   });
@@ -156,6 +52,7 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
     (async () => {
       const newConnection = connection ?? null;
       const newEth = connection?.ethereumProvider ?? null;
+      const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
       const shouldBindToWagmi =
         isConnected &&
         chainNamespace === CHAIN_NAMESPACES.EIP155 &&
@@ -166,39 +63,27 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
         // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
         if (lastSyncedWeb3AuthConnection.current !== newConnection) {
-          if (web3authConnector) {
-            resetConnectorState();
+          if (w3aWagmiConnector) {
+            resetConnectorState(wagmiConfig);
           }
           lastSyncedWeb3AuthConnection.current = newConnection;
-          const connector = await setupConnector(newEth);
+          const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
           if (!connector) {
             log.error("Failed to setup react wagmi connector");
             throw new Error("Failed to setup connector");
           }
 
-          await connectWeb3AuthWithWagmi(connector);
+          await connectWeb3AuthWithWagmi(connector, wagmiConfig);
           reconnect();
         }
       } else if (!isConnected || chainNamespace !== CHAIN_NAMESPACES.EIP155) {
         lastSyncedWeb3AuthConnection.current = null;
-        if (web3authConnector || wagmiConfig.state.status === "connected") {
-          await disconnectWeb3AuthFromWagmi();
+        if (w3aWagmiConnector || wagmiConfig.state.status === "connected") {
+          await disconnectWeb3AuthFromWagmi(wagmiConfig);
         }
       }
     })();
-  }, [
-    chainNamespace,
-    isConnected,
-    wagmiConfig,
-    connection,
-    reconnect,
-    primaryConnectorName,
-    web3authConnector,
-    resetConnectorState,
-    setupConnector,
-    connectWeb3AuthWithWagmi,
-    disconnectWeb3AuthFromWagmi,
-  ]);
+  }, [chainNamespace, isConnected, wagmiConfig, connection, reconnect, primaryConnectorName]);
 
   return createElement(Fragment, null, children);
 }

--- a/packages/modal/src/react/wagmi/provider.ts
+++ b/packages/modal/src/react/wagmi/provider.ts
@@ -1,8 +1,7 @@
 import { CHAIN_NAMESPACES, type CustomChainConfig, log, WalletInitializationError } from "@web3auth/no-modal";
-import { createElement, Fragment, PropsWithChildren, useEffect, useMemo, useRef } from "react";
-import { type Chain, defineChain, http, webSocket } from "viem";
+import { createElement, Fragment, PropsWithChildren, useCallback, useEffect, useMemo, useRef } from "react";
+import { type Chain, defineChain, http, isAddress as isValidEvmAddress, webSocket } from "viem";
 import {
-  Config,
   Connection,
   Connector,
   createConfig as createWagmiConfig,
@@ -22,84 +21,11 @@ import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
 
-function getWeb3authConnector(config: Config) {
-  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-}
-
-// Helper to initialize connectors for the given wallets
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
-
-  if (connector) return connector;
-
-  // Create new connector if not already existing
-  connector = injected({
-    target: {
-      provider: provider,
-      id: WEB3AUTH_CONNECTOR_ID,
-      name: "Web3Auth",
-    },
-  });
-
-  const result = config._internal.connectors.setup(connector);
-  config._internal.connectors.setState((current) => [...current, result]);
-  return result;
-}
-
-// Helper to connect a wallet and update wagmi state
-async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
-  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
-
-  let chainId = await connector.getChainId();
-  if (!config.chains.find((c) => c.id === chainId)) {
-    chainId = config.chains[0].id;
-  }
-
-  const accounts = await connector.getAccounts();
-
-  const connections: Map<string, Connection> = new Map([
-    [
-      connector.uid,
-      {
-        accounts: [accounts[0]],
-        chainId,
-        connector,
-      },
-    ],
-  ]);
-
-  config.setState((state) => ({
-    ...state,
-    chainId,
-    connections,
-    current: connector.uid,
-    status: "connected",
-  }));
-}
-
-function resetConnectorState(config: Config) {
-  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-}
-
-async function disconnectWeb3AuthFromWagmi(config: Config) {
-  const connector = getWeb3authConnector(config);
-  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
-  resetConnectorState(config);
-  config.setState((state) => ({
-    ...state,
-    chainId: state.chainId,
-    connections: new Map(),
-    current: undefined,
-    status: "disconnected",
-  }));
-}
-
 function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const {
     isConnected,
     connection,
+    chainNamespace,
     web3Auth: { primaryConnectorName },
   } = useWeb3Auth();
   const { disconnect } = useWeb3AuthDisconnect();
@@ -107,16 +33,121 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const { mutate: reconnect } = useReconnect();
   const lastSyncedWeb3AuthConnection = useRef<unknown>(null);
 
+  const web3authConnector = useMemo(() => {
+    return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+  }, [wagmiConfig]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createWeb3AuthConnector = useCallback((provider: any): CreateConnectorFn => {
+    const baseConnector = injected({
+      target: {
+        provider: provider,
+        id: WEB3AUTH_CONNECTOR_ID,
+        name: "Web3Auth",
+      },
+    });
+
+    return (config) => {
+      const connector = baseConnector(config);
+      const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+      // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+      // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+      // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+      connector.onAccountsChanged = (accounts: string[]) => {
+        if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isValidEvmAddress(account))) {
+          log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+          return;
+        }
+        baseOnAccountsChanged(accounts);
+      };
+
+      return connector;
+    };
+  }, []);
+
+  // to initialize connectors for the given wallets
+  const setupConnector = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (provider: any) => {
+      if (web3authConnector) return web3authConnector;
+
+      // Create new connector if not already existing
+      const connector = createWeb3AuthConnector(provider);
+
+      const result = wagmiConfig._internal.connectors.setup(connector);
+      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
+      return result;
+    },
+    [wagmiConfig, web3authConnector, createWeb3AuthConnector]
+  );
+
+  // to connect a wallet and update wagmi state
+  const connectWeb3AuthWithWagmi = useCallback(
+    async (connector: Connector) => {
+      await Promise.all([
+        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
+        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
+      ]);
+
+      let chainId = await connector.getChainId();
+      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
+        chainId = wagmiConfig.chains[0].id;
+      }
+
+      const accounts = await connector.getAccounts();
+
+      const connections: Map<string, Connection> = new Map([
+        [
+          connector.uid,
+          {
+            accounts: [accounts[0]],
+            chainId,
+            connector,
+          },
+        ],
+      ]);
+
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId,
+        connections,
+        current: connector.uid,
+        status: "connected",
+      }));
+    },
+    [wagmiConfig]
+  );
+
+  const resetConnectorState = useCallback(() => {
+    wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+    wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+  }, [wagmiConfig]);
+
+  const disconnectWeb3AuthFromWagmi = useCallback(async () => {
+    await Promise.all([
+      wagmiConfig.storage?.setItem(`${web3authConnector?.id}.disconnected`, true),
+      wagmiConfig.storage?.removeItem("injected.connected"),
+    ]);
+    resetConnectorState();
+    wagmiConfig.setState((state) => ({
+      ...state,
+      chainId: state.chainId,
+      connections: new Map(),
+      current: undefined,
+      status: "disconnected",
+    }));
+  }, [wagmiConfig, web3authConnector, resetConnectorState]);
+
   useConnectionEffect({
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
       if (isConnected) await disconnect();
 
-      const connector = getWeb3authConnector(wagmiConfig);
       // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
       // from the connected provider
-      if (connector) {
-        resetConnectorState(wagmiConfig);
+      if (web3authConnector) {
+        resetConnectorState();
       }
     },
   });
@@ -125,31 +156,49 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
     (async () => {
       const newConnection = connection ?? null;
       const newEth = connection?.ethereumProvider ?? null;
-      if (isConnected && newConnection && newEth && newConnection.connectorName === primaryConnectorName) {
+      const shouldBindToWagmi =
+        isConnected &&
+        chainNamespace === CHAIN_NAMESPACES.EIP155 &&
+        Boolean(newConnection && newEth) &&
+        newConnection?.connectorName === primaryConnectorName;
+
+      if (shouldBindToWagmi && newConnection && newEth) {
         // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
         // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
         if (lastSyncedWeb3AuthConnection.current !== newConnection) {
-          if (getWeb3authConnector(wagmiConfig)) {
-            resetConnectorState(wagmiConfig);
+          if (web3authConnector) {
+            resetConnectorState();
           }
           lastSyncedWeb3AuthConnection.current = newConnection;
-          const connector = await setupConnector(newEth, wagmiConfig);
+          const connector = await setupConnector(newEth);
           if (!connector) {
             log.error("Failed to setup react wagmi connector");
             throw new Error("Failed to setup connector");
           }
 
-          await connectWeb3AuthWithWagmi(connector, wagmiConfig);
+          await connectWeb3AuthWithWagmi(connector);
           reconnect();
         }
-      } else if (!isConnected) {
+      } else if (!isConnected || chainNamespace !== CHAIN_NAMESPACES.EIP155) {
         lastSyncedWeb3AuthConnection.current = null;
-        if (wagmiConfig.state.status === "connected") {
-          await disconnectWeb3AuthFromWagmi(wagmiConfig);
+        if (web3authConnector || wagmiConfig.state.status === "connected") {
+          await disconnectWeb3AuthFromWagmi();
         }
       }
     })();
-  }, [isConnected, wagmiConfig, connection, reconnect, primaryConnectorName]);
+  }, [
+    chainNamespace,
+    isConnected,
+    wagmiConfig,
+    connection,
+    reconnect,
+    primaryConnectorName,
+    web3authConnector,
+    resetConnectorState,
+    setupConnector,
+    connectWeb3AuthWithWagmi,
+    disconnectWeb3AuthFromWagmi,
+  ]);
 
   return createElement(Fragment, null, children);
 }

--- a/packages/modal/src/vue/wagmi/provider.ts
+++ b/packages/modal/src/vue/wagmi/provider.ts
@@ -62,7 +62,7 @@ const Web3AuthWagmiProvider = defineComponent({
               resetConnectorState(wagmiConfig);
             }
             lastSyncedWeb3AuthConnection.value = newConnection;
-            const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
+            const connector = setupConnector(newEth, wagmiConfig);
             if (!connector) {
               log.error("Failed to setup vue wagmi connector");
               throw new Error("Failed to setup connector");

--- a/packages/modal/src/vue/wagmi/provider.ts
+++ b/packages/modal/src/vue/wagmi/provider.ts
@@ -3,7 +3,7 @@ import { configKey, createConfig as createWagmiConfig, useConfig as useWagmiConf
 import { injected } from "@wagmi/vue/connectors";
 import { randomId } from "@web3auth/auth";
 import { CHAIN_NAMESPACES, type CustomChainConfig, log, WalletInitializationError } from "@web3auth/no-modal";
-import { type Chain, defineChain, fallback, http, webSocket } from "viem";
+import { type Chain, defineChain, fallback, http, isAddress as isValidEvmAddress, webSocket } from "viem";
 import { defineComponent, h, PropType, provide, ref, shallowRef, watch } from "vue";
 
 // import type { Config, Connection, Connector, CreateConfigParameters, CreateConnectorFn } from "wagmi";
@@ -12,80 +12,6 @@ import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
-
-function getWeb3authConnector(config: Config) {
-  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-}
-
-// Helper to initialize connectors for the given wallets
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
-
-  if (connector) return connector;
-
-  // Create new connector if not already existing
-  connector = injected({
-    target: {
-      provider: provider,
-      id: WEB3AUTH_CONNECTOR_ID,
-      name: "Web3Auth",
-    },
-  });
-
-  const result = config._internal.connectors.setup(connector);
-  config._internal.connectors.setState((current) => [...current, result]);
-  return result;
-}
-
-// Helper to connect a wallet and update wagmi state
-async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
-  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
-
-  let chainId = await connector.getChainId();
-  if (!config.chains.find((c) => c.id === chainId)) {
-    chainId = config.chains[0].id;
-  }
-
-  const accounts = await connector.getAccounts();
-
-  const connections: Map<string, Connection> = new Map([
-    [
-      connector.uid,
-      {
-        accounts: [accounts[0]],
-        chainId,
-        connector,
-      },
-    ],
-  ]);
-
-  config.setState((state) => ({
-    ...state,
-    chainId,
-    connections,
-    current: connector.uid,
-    status: "connected",
-  }));
-}
-
-function resetConnectorState(config: Config) {
-  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-}
-
-async function disconnectWeb3AuthFromWagmi(config: Config) {
-  const connector = getWeb3authConnector(config);
-  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
-  resetConnectorState(config);
-  config.setState((state) => ({
-    ...state,
-    chainId: state.chainId,
-    connections: new Map(),
-    current: undefined,
-    status: "disconnected",
-  }));
-}
 
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
@@ -96,47 +22,153 @@ const Web3AuthWagmiProvider = defineComponent({
     const { mutate: reconnect } = useReconnect();
     const lastSyncedWeb3AuthConnection = shallowRef<unknown>(null);
 
+    function getWeb3authConnector() {
+      return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+    }
+
+    function resetConnectorState() {
+      wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+      wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+    }
+
+    async function disconnectWeb3AuthFromWagmi() {
+      const connector = getWeb3authConnector();
+      await Promise.all([wagmiConfig.storage?.setItem(`${connector?.id}.disconnected`, true), wagmiConfig.storage?.removeItem("injected.connected")]);
+      resetConnectorState();
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId: state.chainId,
+        connections: new Map(),
+        current: undefined,
+        status: "disconnected",
+      }));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function createWeb3AuthConnector(provider: any): CreateConnectorFn {
+      const baseConnector = injected({
+        target: {
+          provider: provider,
+          id: WEB3AUTH_CONNECTOR_ID,
+          name: "Web3Auth",
+        },
+      });
+
+      return (config) => {
+        const connector = baseConnector(config);
+        const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+        connector.onAccountsChanged = (accounts: string[]) => {
+          // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+          // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+          // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+          if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isValidEvmAddress(account))) {
+            log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+            return;
+          }
+          baseOnAccountsChanged(accounts);
+        };
+
+        return connector;
+      };
+    }
+
+    // Helper to initialize connectors for the given wallets
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async function setupConnector(provider: any) {
+      let connector: Connector | CreateConnectorFn = getWeb3authConnector();
+
+      if (connector) return connector;
+
+      // Create new connector if not already existing
+      connector = createWeb3AuthConnector(provider);
+
+      const result = wagmiConfig._internal.connectors.setup(connector);
+      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
+      return result;
+    }
+
+    // Helper to connect a wallet and update wagmi state
+    async function connectWeb3AuthWithWagmi(connector: Connector) {
+      await Promise.all([
+        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
+        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
+      ]);
+
+      let chainId = await connector.getChainId();
+      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
+        chainId = wagmiConfig.chains[0].id;
+      }
+
+      const accounts = await connector.getAccounts();
+
+      const connections: Map<string, Connection> = new Map([
+        [
+          connector.uid,
+          {
+            accounts: [accounts[0]],
+            chainId,
+            connector,
+          },
+        ],
+      ]);
+
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId,
+        connections,
+        current: connector.uid,
+        status: "connected",
+      }));
+    }
+
     useConnectionEffect({
       onDisconnect: async () => {
         log.info("Disconnected from wagmi");
         if (isConnected.value) await disconnect();
 
-        const connector = getWeb3authConnector(wagmiConfig);
+        const connector = getWeb3authConnector();
         // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
         // from the connected provider
         if (connector) {
-          resetConnectorState(wagmiConfig);
+          resetConnectorState();
         }
       },
     });
 
     watch(
-      [isConnected, connection],
+      [isConnected, connection, () => web3Auth.value?.currentChain?.chainNamespace],
       async () => {
         const newIsConnected = isConnected.value;
         const newConnection = connection.value;
         const newEth = newConnection?.ethereumProvider ?? null;
-        if (newIsConnected && newConnection && newEth && newConnection.connectorName === web3Auth.value?.primaryConnectorName) {
+        const currentChainNamespace = web3Auth.value?.currentChain?.chainNamespace ?? null;
+        const shouldBindToWagmi =
+          newIsConnected &&
+          currentChainNamespace === CHAIN_NAMESPACES.EIP155 &&
+          Boolean(newConnection && newEth) &&
+          newConnection?.connectorName === web3Auth.value?.primaryConnectorName;
+        if (shouldBindToWagmi && newConnection && newEth) {
           // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
           // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
           if (lastSyncedWeb3AuthConnection.value !== newConnection) {
-            if (getWeb3authConnector(wagmiConfig)) {
-              resetConnectorState(wagmiConfig);
+            if (getWeb3authConnector()) {
+              resetConnectorState();
             }
             lastSyncedWeb3AuthConnection.value = newConnection;
-            const connector = await setupConnector(newEth, wagmiConfig);
+            const connector = await setupConnector(newEth);
             if (!connector) {
               log.error("Failed to setup vue wagmi connector");
               throw new Error("Failed to setup connector");
             }
 
-            await connectWeb3AuthWithWagmi(connector, wagmiConfig);
+            await connectWeb3AuthWithWagmi(connector);
             reconnect();
           }
-        } else if (!newIsConnected) {
+        } else if (!newIsConnected || currentChainNamespace !== CHAIN_NAMESPACES.EIP155) {
           lastSyncedWeb3AuthConnection.value = null;
-          if (wagmiConfig.state.status === "connected") {
-            await disconnectWeb3AuthFromWagmi(wagmiConfig);
+          if (getWeb3authConnector() || wagmiConfig.state.status === "connected") {
+            await disconnectWeb3AuthFromWagmi();
           }
         }
       },

--- a/packages/modal/src/vue/wagmi/provider.ts
+++ b/packages/modal/src/vue/wagmi/provider.ts
@@ -21,16 +21,19 @@ import { WagmiProviderProps } from "./interface";
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
   setup() {
-    const { isConnected, connection, web3Auth } = useWeb3Auth();
+    const { isConnected, connection, web3Auth, chainNamespace } = useWeb3Auth();
     const { disconnect } = useWeb3AuthDisconnect();
     const wagmiConfig = useWagmiConfig();
     const { mutate: reconnect } = useReconnect();
     const lastSyncedWeb3AuthConnection = shallowRef<unknown>(null);
+    const suppressWagmiDisconnect = ref(false);
 
     useConnectionEffect({
       onDisconnect: async () => {
         log.info("Disconnected from wagmi");
-        if (isConnected.value) await disconnect();
+        const isSuppressed = suppressWagmiDisconnect.value;
+        suppressWagmiDisconnect.value = false;
+        if (!isSuppressed && isConnected.value) await disconnect();
 
         const connector = getWeb3authConnector(wagmiConfig);
         // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
@@ -42,18 +45,19 @@ const Web3AuthWagmiProvider = defineComponent({
     });
 
     watch(
-      [isConnected, connection, () => web3Auth.value?.currentChain?.chainNamespace],
+      [isConnected, connection, chainNamespace],
       async () => {
         const newIsConnected = isConnected.value;
         const newConnection = connection.value;
         const newEth = newConnection?.ethereumProvider ?? null;
-        const currentChainNamespace = web3Auth.value?.currentChain?.chainNamespace ?? null;
+        const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
+
         const shouldBindToWagmi =
           newIsConnected &&
-          currentChainNamespace === CHAIN_NAMESPACES.EIP155 &&
+          chainNamespace.value === CHAIN_NAMESPACES.EIP155 &&
           Boolean(newConnection && newEth) &&
           newConnection?.connectorName === web3Auth.value?.primaryConnectorName;
-        const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
+
         if (shouldBindToWagmi && newConnection && newEth) {
           // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
           // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
@@ -71,10 +75,13 @@ const Web3AuthWagmiProvider = defineComponent({
             await connectWeb3AuthWithWagmi(connector, wagmiConfig);
             reconnect();
           }
-        } else if (!newIsConnected || currentChainNamespace !== CHAIN_NAMESPACES.EIP155) {
+        } else if (!newIsConnected || chainNamespace.value !== CHAIN_NAMESPACES.EIP155) {
           lastSyncedWeb3AuthConnection.value = null;
-          if (w3aWagmiConnector || wagmiConfig.state.status === "connected") {
+          if (wagmiConfig.state.status === "connected") {
+            suppressWagmiDisconnect.value = true;
             await disconnectWeb3AuthFromWagmi(wagmiConfig);
+          } else if (w3aWagmiConnector) {
+            resetConnectorState(wagmiConfig);
           }
         }
       },

--- a/packages/modal/src/vue/wagmi/provider.ts
+++ b/packages/modal/src/vue/wagmi/provider.ts
@@ -1,9 +1,15 @@
-import { Config, Connection, Connector, CreateConfigParameters, CreateConnectorFn, hydrate } from "@wagmi/core";
+import { Config, CreateConfigParameters, hydrate } from "@wagmi/core";
 import { configKey, createConfig as createWagmiConfig, useConfig as useWagmiConfig, useConnectionEffect, useReconnect } from "@wagmi/vue";
-import { injected } from "@wagmi/vue/connectors";
 import { randomId } from "@web3auth/auth";
 import { CHAIN_NAMESPACES, type CustomChainConfig, log, WalletInitializationError } from "@web3auth/no-modal";
-import { type Chain, defineChain, fallback, http, isAddress as isValidEvmAddress, webSocket } from "viem";
+import {
+  connectWeb3AuthWithWagmi,
+  disconnectWeb3AuthFromWagmi,
+  getWeb3authConnector,
+  resetConnectorState,
+  setupConnector,
+} from "@web3auth/no-modal/vue/wagmi";
+import { type Chain, defineChain, fallback, http, webSocket } from "viem";
 import { defineComponent, h, PropType, provide, ref, shallowRef, watch } from "vue";
 
 // import type { Config, Connection, Connector, CreateConfigParameters, CreateConnectorFn } from "wagmi";
@@ -11,8 +17,7 @@ import { useWeb3Auth, useWeb3AuthDisconnect } from "../composables";
 import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
-const WEB3AUTH_CONNECTOR_ID = "web3auth";
-
+// TODO: re-use the provider from the no-modal package
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
   setup() {
@@ -22,116 +27,16 @@ const Web3AuthWagmiProvider = defineComponent({
     const { mutate: reconnect } = useReconnect();
     const lastSyncedWeb3AuthConnection = shallowRef<unknown>(null);
 
-    function getWeb3authConnector() {
-      return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-    }
-
-    function resetConnectorState() {
-      wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-      wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-    }
-
-    async function disconnectWeb3AuthFromWagmi() {
-      const connector = getWeb3authConnector();
-      await Promise.all([wagmiConfig.storage?.setItem(`${connector?.id}.disconnected`, true), wagmiConfig.storage?.removeItem("injected.connected")]);
-      resetConnectorState();
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId: state.chainId,
-        connections: new Map(),
-        current: undefined,
-        status: "disconnected",
-      }));
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function createWeb3AuthConnector(provider: any): CreateConnectorFn {
-      const baseConnector = injected({
-        target: {
-          provider: provider,
-          id: WEB3AUTH_CONNECTOR_ID,
-          name: "Web3Auth",
-        },
-      });
-
-      return (config) => {
-        const connector = baseConnector(config);
-        const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
-
-        connector.onAccountsChanged = (accounts: string[]) => {
-          // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
-          // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
-          // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
-          if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isValidEvmAddress(account))) {
-            log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
-            return;
-          }
-          baseOnAccountsChanged(accounts);
-        };
-
-        return connector;
-      };
-    }
-
-    // Helper to initialize connectors for the given wallets
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async function setupConnector(provider: any) {
-      let connector: Connector | CreateConnectorFn = getWeb3authConnector();
-
-      if (connector) return connector;
-
-      // Create new connector if not already existing
-      connector = createWeb3AuthConnector(provider);
-
-      const result = wagmiConfig._internal.connectors.setup(connector);
-      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
-      return result;
-    }
-
-    // Helper to connect a wallet and update wagmi state
-    async function connectWeb3AuthWithWagmi(connector: Connector) {
-      await Promise.all([
-        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
-        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
-      ]);
-
-      let chainId = await connector.getChainId();
-      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
-        chainId = wagmiConfig.chains[0].id;
-      }
-
-      const accounts = await connector.getAccounts();
-
-      const connections: Map<string, Connection> = new Map([
-        [
-          connector.uid,
-          {
-            accounts: [accounts[0]],
-            chainId,
-            connector,
-          },
-        ],
-      ]);
-
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId,
-        connections,
-        current: connector.uid,
-        status: "connected",
-      }));
-    }
-
     useConnectionEffect({
       onDisconnect: async () => {
         log.info("Disconnected from wagmi");
         if (isConnected.value) await disconnect();
 
-        const connector = getWeb3authConnector();
+        const connector = getWeb3authConnector(wagmiConfig);
         // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
         // from the connected provider
         if (connector) {
-          resetConnectorState();
+          resetConnectorState(wagmiConfig);
         }
       },
     });
@@ -148,27 +53,28 @@ const Web3AuthWagmiProvider = defineComponent({
           currentChainNamespace === CHAIN_NAMESPACES.EIP155 &&
           Boolean(newConnection && newEth) &&
           newConnection?.connectorName === web3Auth.value?.primaryConnectorName;
+        const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
         if (shouldBindToWagmi && newConnection && newEth) {
           // `ethereumProvider` is a stable proxy (`commonJRPCProvider`) across account switches,
           // so key wagmi resyncs off the Web3Auth connection object instead of provider identity.
           if (lastSyncedWeb3AuthConnection.value !== newConnection) {
-            if (getWeb3authConnector()) {
-              resetConnectorState();
+            if (w3aWagmiConnector) {
+              resetConnectorState(wagmiConfig);
             }
             lastSyncedWeb3AuthConnection.value = newConnection;
-            const connector = await setupConnector(newEth);
+            const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
             if (!connector) {
               log.error("Failed to setup vue wagmi connector");
               throw new Error("Failed to setup connector");
             }
 
-            await connectWeb3AuthWithWagmi(connector);
+            await connectWeb3AuthWithWagmi(connector, wagmiConfig);
             reconnect();
           }
         } else if (!newIsConnected || currentChainNamespace !== CHAIN_NAMESPACES.EIP155) {
           lastSyncedWeb3AuthConnection.value = null;
-          if (getWeb3authConnector() || wagmiConfig.state.status === "connected") {
-            await disconnectWeb3AuthFromWagmi();
+          if (w3aWagmiConnector || wagmiConfig.state.status === "connected") {
+            await disconnectWeb3AuthFromWagmi(wagmiConfig);
           }
         }
       },

--- a/packages/no-modal/src/base/connector/constants.ts
+++ b/packages/no-modal/src/base/connector/constants.ts
@@ -1,3 +1,5 @@
+export const WEB3AUTH_CONNECTOR_ID = "web3auth";
+
 export const CONNECTOR_STATUS = {
   NOT_READY: "not_ready",
   READY: "ready",

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -1,6 +1,7 @@
-import { createElement, Fragment, PropsWithChildren, useCallback, useEffect, useMemo, useRef } from "react";
+import { createElement, Fragment, PropsWithChildren, useEffect, useMemo, useRef } from "react";
 import { type Chain, defineChain, isAddress as isEvmAddress } from "viem";
 import {
+  Config,
   Connection,
   Connector,
   createConfig as createWagmiConfig,
@@ -16,12 +17,105 @@ import {
 } from "wagmi";
 import { injected } from "wagmi/connectors";
 
-import { CHAIN_NAMESPACES, CustomChainConfig, log, WalletInitializationError } from "../../base";
+import { CHAIN_NAMESPACES, CustomChainConfig, log, WalletInitializationError, WEB3AUTH_CONNECTOR_ID } from "../../base";
 import { useWeb3Auth, useWeb3AuthDisconnect } from "../hooks";
 import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
-const WEB3AUTH_CONNECTOR_ID = "web3auth";
+export function getWeb3authConnector(config: Config) {
+  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+}
+
+// Helper to create a Web3Auth connector to connect with wagmi
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createWeb3AuthConnectorForWagmi(provider: any): CreateConnectorFn {
+  const baseConnector = injected({
+    target: {
+      provider: provider,
+      id: WEB3AUTH_CONNECTOR_ID,
+      name: "Web3Auth",
+    },
+  });
+
+  return (config) => {
+    const connector = baseConnector(config);
+    const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+    // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+    // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+    // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+    connector.onAccountsChanged = (accounts: string[]) => {
+      if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
+        log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+        return;
+      }
+      baseOnAccountsChanged(accounts);
+    };
+
+    return connector;
+  };
+}
+
+// Helper to initialize connectors for the given wallets
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setupConnector(provider: any, config: Config, connector?: Connector): Connector {
+  if (connector) return connector;
+
+  // Create new connector if not already existing
+  const w3aConnector = createWeb3AuthConnectorForWagmi(provider);
+
+  const result = config._internal.connectors.setup(w3aConnector);
+  config._internal.connectors.setState((current) => [...current, result]);
+  return result;
+}
+
+export async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
+  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
+
+  let chainId = await connector.getChainId();
+  if (!config.chains.find((c) => c.id === chainId)) {
+    chainId = config.chains[0].id;
+  }
+
+  const accounts = await connector.getAccounts();
+
+  const connections: Map<string, Connection> = new Map([
+    [
+      connector.uid,
+      {
+        accounts: [accounts[0]],
+        chainId,
+        connector,
+      },
+    ],
+  ]);
+
+  config.setState((state) => ({
+    ...state,
+    chainId,
+    connections,
+    current: connector.uid,
+    status: "connected",
+  }));
+}
+
+export function resetConnectorState(config: Config) {
+  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+}
+
+export async function disconnectWeb3AuthFromWagmi(config: Config) {
+  const connector = getWeb3authConnector(config);
+  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
+  resetConnectorState(config);
+  config.setState((state) => ({
+    ...state,
+    chainId: state.chainId,
+    connections: new Map(),
+    current: undefined,
+    status: "disconnected",
+  }));
+}
 
 function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const { isConnected, connection, chainNamespace } = useWeb3Auth();
@@ -34,114 +128,6 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
     connectorName: null,
   });
 
-  const web3authConnector = useMemo(() => {
-    return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-  }, [wagmiConfig]);
-
-  const resetConnectorState = useCallback(() => {
-    wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-    wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-  }, [wagmiConfig]);
-
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const createWeb3AuthConnector = useCallback((provider: any): CreateConnectorFn => {
-    const baseConnector = injected({
-      target: {
-        provider: provider,
-        id: WEB3AUTH_CONNECTOR_ID,
-        name: "Web3Auth",
-      },
-    });
-
-    return (config) => {
-      const connector = baseConnector(config);
-      const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
-
-      // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
-      // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
-      // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
-      connector.onAccountsChanged = (accounts: string[]) => {
-        if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
-          log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
-          return;
-        }
-        baseOnAccountsChanged(accounts);
-      };
-
-      return connector;
-    };
-  }, []);
-
-  // to connect a wallet and update wagmi state
-  const connectWeb3AuthWithWagmi = useCallback(
-    async (connector: Connector) => {
-      await Promise.all([
-        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
-        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
-      ]);
-
-      let chainId = await connector.getChainId();
-      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
-        chainId = wagmiConfig.chains[0].id;
-      }
-
-      const accounts = await connector.getAccounts();
-
-      const connections: Map<string, Connection> = new Map([
-        [
-          connector.uid,
-          {
-            accounts: [accounts[0]],
-            chainId,
-            connector,
-          },
-        ],
-      ]);
-
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId,
-        connections,
-        current: connector.uid,
-        status: "connected",
-      }));
-    },
-    [wagmiConfig]
-  );
-
-  // Initialize connectors for the given wallets
-  const setupConnector = useCallback(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async (provider: any) => {
-      let connector: Connector | CreateConnectorFn = web3authConnector;
-
-      if (connector) return connector;
-
-      // Create new connector if not already existing
-      connector = createWeb3AuthConnector(provider);
-
-      const result = wagmiConfig._internal.connectors.setup(connector);
-      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
-      return result;
-    },
-    [wagmiConfig, web3authConnector]
-  );
-
-  const disconnectWeb3AuthFromWagmi = useCallback(async () => {
-    await Promise.all([
-      wagmiConfig.storage?.setItem(`${web3authConnector?.id}.disconnected`, true),
-      wagmiConfig.storage?.removeItem("injected.connected"),
-    ]);
-    resetConnectorState();
-    wagmiConfig.setState((state) => ({
-      ...state,
-      chainId: state.chainId,
-      connections: new Map(),
-      current: undefined,
-      status: "disconnected",
-    }));
-  }, [wagmiConfig, web3authConnector]);
-
   useConnectionEffect({
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
@@ -151,8 +137,8 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
 
       // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
       // from the connected provider
-      if (web3authConnector) {
-        resetConnectorState();
+      if (getWeb3authConnector(wagmiConfig)) {
+        resetConnectorState(wagmiConfig);
       }
     },
   });
@@ -160,7 +146,7 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   useEffect(() => {
     (async () => {
       const shouldBindToWagmi = isConnected && chainNamespace === CHAIN_NAMESPACES.EIP155 && Boolean(connection?.ethereumProvider);
-
+      const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
       if (shouldBindToWagmi) {
         const hasSameBinding =
           lastSyncedBinding.current.provider === connection.ethereumProvider && lastSyncedBinding.current.connectorName === connection.connectorName;
@@ -168,22 +154,21 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         if (hasSameBinding && wagmiConfig.state.status === "connected") {
           return;
         }
-
-        if (!hasSameBinding && web3authConnector) {
+        if (!hasSameBinding && w3aWagmiConnector) {
           if (wagmiConfig.state.status === "connected") {
             suppressWagmiDisconnect.current = true;
-            await disconnectWeb3AuthFromWagmi();
+            await disconnectWeb3AuthFromWagmi(wagmiConfig);
           } else {
-            resetConnectorState();
+            resetConnectorState(wagmiConfig);
           }
         }
 
-        const connector = await setupConnector(connection.ethereumProvider);
+        const connector = setupConnector(connection.ethereumProvider, wagmiConfig, w3aWagmiConnector);
         if (!connector) {
           throw new Error("Failed to setup connector");
         }
 
-        await connectWeb3AuthWithWagmi(connector);
+        await connectWeb3AuthWithWagmi(connector, wagmiConfig);
         lastSyncedBinding.current = {
           provider: connection.ethereumProvider,
           connectorName: connection.connectorName,
@@ -193,9 +178,9 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         lastSyncedBinding.current = { provider: null, connectorName: null };
         if (wagmiConfig.state.status === "connected") {
           suppressWagmiDisconnect.current = true;
-          await disconnectWeb3AuthFromWagmi();
-        } else if (web3authConnector) {
-          resetConnectorState();
+          await disconnectWeb3AuthFromWagmi(wagmiConfig);
+        } else if (w3aWagmiConnector) {
+          resetConnectorState(wagmiConfig);
         }
       }
     })();

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -1,7 +1,6 @@
-import { createElement, Fragment, PropsWithChildren, useEffect, useMemo, useRef } from "react";
-import { type Chain, defineChain } from "viem";
+import { createElement, Fragment, PropsWithChildren, useCallback, useEffect, useMemo, useRef } from "react";
+import { type Chain, defineChain, isAddress as isEvmAddress } from "viem";
 import {
-  Config,
   Connection,
   Connector,
   createConfig as createWagmiConfig,
@@ -24,80 +23,6 @@ import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
 
-function getWeb3authConnector(config: Config) {
-  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-}
-
-// Helper to initialize connectors for the given wallets
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
-
-  if (connector) return connector;
-
-  // Create new connector if not already existing
-  connector = injected({
-    target: {
-      provider: provider,
-      id: WEB3AUTH_CONNECTOR_ID,
-      name: "Web3Auth",
-    },
-  });
-
-  const result = config._internal.connectors.setup(connector);
-  config._internal.connectors.setState((current) => [...current, result]);
-  return result;
-}
-
-// Helper to connect a wallet and update wagmi state
-async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
-  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
-
-  let chainId = await connector.getChainId();
-  if (!config.chains.find((c) => c.id === chainId)) {
-    chainId = config.chains[0].id;
-  }
-
-  const accounts = await connector.getAccounts();
-
-  const connections: Map<string, Connection> = new Map([
-    [
-      connector.uid,
-      {
-        accounts: [accounts[0]],
-        chainId,
-        connector,
-      },
-    ],
-  ]);
-
-  config.setState((state) => ({
-    ...state,
-    chainId,
-    connections,
-    current: connector.uid,
-    status: "connected",
-  }));
-}
-
-function resetConnectorState(config: Config) {
-  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-}
-
-async function disconnectWeb3AuthFromWagmi(config: Config) {
-  const connector = getWeb3authConnector(config);
-  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
-  resetConnectorState(config);
-  config.setState((state) => ({
-    ...state,
-    chainId: state.chainId,
-    connections: new Map(),
-    current: undefined,
-    status: "disconnected",
-  }));
-}
-
 function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
   const { isConnected, connection, chainNamespace } = useWeb3Auth();
   const { disconnect } = useWeb3AuthDisconnect();
@@ -109,6 +34,114 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
     connectorName: null,
   });
 
+  const web3authConnector = useMemo(() => {
+    return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+  }, [wagmiConfig]);
+
+  const resetConnectorState = useCallback(() => {
+    wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+    wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+  }, [wagmiConfig]);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const createWeb3AuthConnector = useCallback((provider: any): CreateConnectorFn => {
+    const baseConnector = injected({
+      target: {
+        provider: provider,
+        id: WEB3AUTH_CONNECTOR_ID,
+        name: "Web3Auth",
+      },
+    });
+
+    return (config) => {
+      const connector = baseConnector(config);
+      const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+      // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+      // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+      // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+      connector.onAccountsChanged = (accounts: string[]) => {
+        if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
+          log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+          return;
+        }
+        baseOnAccountsChanged(accounts);
+      };
+
+      return connector;
+    };
+  }, []);
+
+  // to connect a wallet and update wagmi state
+  const connectWeb3AuthWithWagmi = useCallback(
+    async (connector: Connector) => {
+      await Promise.all([
+        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
+        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
+      ]);
+
+      let chainId = await connector.getChainId();
+      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
+        chainId = wagmiConfig.chains[0].id;
+      }
+
+      const accounts = await connector.getAccounts();
+
+      const connections: Map<string, Connection> = new Map([
+        [
+          connector.uid,
+          {
+            accounts: [accounts[0]],
+            chainId,
+            connector,
+          },
+        ],
+      ]);
+
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId,
+        connections,
+        current: connector.uid,
+        status: "connected",
+      }));
+    },
+    [wagmiConfig]
+  );
+
+  // Initialize connectors for the given wallets
+  const setupConnector = useCallback(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async (provider: any) => {
+      let connector: Connector | CreateConnectorFn = web3authConnector;
+
+      if (connector) return connector;
+
+      // Create new connector if not already existing
+      connector = createWeb3AuthConnector(provider);
+
+      const result = wagmiConfig._internal.connectors.setup(connector);
+      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
+      return result;
+    },
+    [wagmiConfig, web3authConnector]
+  );
+
+  const disconnectWeb3AuthFromWagmi = useCallback(async () => {
+    await Promise.all([
+      wagmiConfig.storage?.setItem(`${web3authConnector?.id}.disconnected`, true),
+      wagmiConfig.storage?.removeItem("injected.connected"),
+    ]);
+    resetConnectorState();
+    wagmiConfig.setState((state) => ({
+      ...state,
+      chainId: state.chainId,
+      connections: new Map(),
+      current: undefined,
+      status: "disconnected",
+    }));
+  }, [wagmiConfig, web3authConnector]);
+
   useConnectionEffect({
     onDisconnect: async () => {
       log.info("Disconnected from wagmi");
@@ -116,11 +149,10 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
       suppressWagmiDisconnect.current = false;
       if (!isSuppressed && isConnected) await disconnect();
 
-      const connector = getWeb3authConnector(wagmiConfig);
       // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
       // from the connected provider
-      if (connector) {
-        resetConnectorState(wagmiConfig);
+      if (web3authConnector) {
+        resetConnectorState();
       }
     },
   });
@@ -137,21 +169,21 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
           return;
         }
 
-        if (!hasSameBinding && getWeb3authConnector(wagmiConfig)) {
+        if (!hasSameBinding && web3authConnector) {
           if (wagmiConfig.state.status === "connected") {
             suppressWagmiDisconnect.current = true;
-            await disconnectWeb3AuthFromWagmi(wagmiConfig);
+            await disconnectWeb3AuthFromWagmi();
           } else {
-            resetConnectorState(wagmiConfig);
+            resetConnectorState();
           }
         }
 
-        const connector = await setupConnector(connection.ethereumProvider, wagmiConfig);
+        const connector = await setupConnector(connection.ethereumProvider);
         if (!connector) {
           throw new Error("Failed to setup connector");
         }
 
-        await connectWeb3AuthWithWagmi(connector, wagmiConfig);
+        await connectWeb3AuthWithWagmi(connector);
         lastSyncedBinding.current = {
           provider: connection.ethereumProvider,
           connectorName: connection.connectorName,
@@ -161,9 +193,9 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
         lastSyncedBinding.current = { provider: null, connectorName: null };
         if (wagmiConfig.state.status === "connected") {
           suppressWagmiDisconnect.current = true;
-          await disconnectWeb3AuthFromWagmi(wagmiConfig);
-        } else if (getWeb3authConnector(wagmiConfig)) {
-          resetConnectorState(wagmiConfig);
+          await disconnectWeb3AuthFromWagmi();
+        } else if (web3authConnector) {
+          resetConnectorState();
         }
       }
     })();

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -120,7 +120,12 @@ export async function disconnectWeb3AuthFromWagmi(config: Config) {
 }
 
 function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
-  const { isConnected, connection, chainNamespace } = useWeb3Auth();
+  const {
+    isConnected,
+    connection,
+    chainNamespace,
+    web3Auth: { primaryConnectorName },
+  } = useWeb3Auth();
   const { disconnect } = useWeb3AuthDisconnect();
   const wagmiConfig = useWagmiConfig();
   const { mutate: reconnect } = useReconnect();
@@ -147,11 +152,17 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
 
   useEffect(() => {
     (async () => {
-      const shouldBindToWagmi = isConnected && chainNamespace === CHAIN_NAMESPACES.EIP155 && Boolean(connection?.ethereumProvider);
+      const newConnection = connection ?? null;
+      const newEth = connection?.ethereumProvider ?? null;
       const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
+      const shouldBindToWagmi =
+        isConnected &&
+        chainNamespace === CHAIN_NAMESPACES.EIP155 &&
+        Boolean(newConnection && newEth) &&
+        newConnection?.connectorName === primaryConnectorName;
+
       if (shouldBindToWagmi) {
-        const hasSameBinding =
-          lastSyncedBinding.current.provider === connection.ethereumProvider && lastSyncedBinding.current.connectorName === connection.connectorName;
+        const hasSameBinding = lastSyncedBinding.current.provider === newEth && lastSyncedBinding.current.connectorName === connection.connectorName;
 
         if (hasSameBinding && wagmiConfig.state.status === "connected") {
           return;
@@ -165,14 +176,14 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
           }
         }
 
-        const connector = setupConnector(connection.ethereumProvider, wagmiConfig);
+        const connector = setupConnector(newEth, wagmiConfig);
         if (!connector) {
           throw new Error("Failed to setup connector");
         }
 
         await connectWeb3AuthWithWagmi(connector, wagmiConfig);
         lastSyncedBinding.current = {
-          provider: connection.ethereumProvider,
+          provider: newEth,
           connectorName: connection.connectorName,
         };
         reconnect();

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -58,13 +58,15 @@ export function createWeb3AuthConnectorForWagmi(provider: any): CreateConnectorF
 
 // Helper to initialize connectors for the given wallets
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setupConnector(provider: any, config: Config, connector?: Connector): Connector {
+export function setupConnector(provider: any, config: Config): Connector {
+  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
+
   if (connector) return connector;
 
   // Create new connector if not already existing
-  const w3aConnector = createWeb3AuthConnectorForWagmi(provider);
+  connector = createWeb3AuthConnectorForWagmi(provider);
 
-  const result = config._internal.connectors.setup(w3aConnector);
+  const result = config._internal.connectors.setup(connector);
   config._internal.connectors.setState((current) => [...current, result]);
   return result;
 }
@@ -163,7 +165,7 @@ function Web3AuthWagmiProvider({ children }: PropsWithChildren) {
           }
         }
 
-        const connector = setupConnector(connection.ethereumProvider, wagmiConfig, w3aWagmiConnector);
+        const connector = setupConnector(connection.ethereumProvider, wagmiConfig);
         if (!connector) {
           throw new Error("Failed to setup connector");
         }

--- a/packages/no-modal/src/vue/wagmi/provider.ts
+++ b/packages/no-modal/src/vue/wagmi/provider.ts
@@ -9,7 +9,7 @@ import {
 } from "@wagmi/vue";
 import { injected } from "@wagmi/vue/connectors";
 import { randomId } from "@web3auth/auth";
-import { type Chain, defineChain, fallback, http, webSocket } from "viem";
+import { type Chain, defineChain, fallback, http, isAddress as isEvmAddress, webSocket } from "viem";
 import { defineComponent, h, PropType, provide, ref, shallowRef, watch } from "vue";
 
 import { CHAIN_NAMESPACES, type CustomChainConfig, WalletInitializationError } from "../../base";
@@ -20,80 +20,6 @@ import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
 const WEB3AUTH_CONNECTOR_ID = "web3auth";
-
-function getWeb3authConnector(config: Config) {
-  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-}
-
-// Helper to initialize connectors for the given wallets
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function setupConnector(provider: any, config: Config) {
-  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
-
-  if (connector) return connector;
-
-  // Create new connector if not already existing
-  connector = injected({
-    target: {
-      provider: provider,
-      id: WEB3AUTH_CONNECTOR_ID,
-      name: "Web3Auth",
-    },
-  });
-
-  const result = config._internal.connectors.setup(connector);
-  config._internal.connectors.setState((current) => [...current, result]);
-  return result;
-}
-
-// Helper to connect a wallet and update wagmi state
-async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
-  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
-
-  let chainId = await connector.getChainId();
-  if (!config.chains.find((c) => c.id === chainId)) {
-    chainId = config.chains[0].id;
-  }
-
-  const accounts = await connector.getAccounts();
-
-  const connections: Map<string, Connection> = new Map([
-    [
-      connector.uid,
-      {
-        accounts: [accounts[0]],
-        chainId,
-        connector,
-      },
-    ],
-  ]);
-
-  config.setState((state) => ({
-    ...state,
-    chainId,
-    connections,
-    current: connector.uid,
-    status: "connected",
-  }));
-}
-
-function resetConnectorState(config: Config) {
-  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-}
-
-async function disconnectWeb3AuthFromWagmi(config: Config) {
-  const connector = getWeb3authConnector(config);
-  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
-  resetConnectorState(config);
-  config.setState((state) => ({
-    ...state,
-    chainId: state.chainId,
-    connections: new Map(),
-    current: undefined,
-    status: "disconnected",
-  }));
-}
 
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
@@ -106,6 +32,105 @@ const Web3AuthWagmiProvider = defineComponent({
     const lastSyncedConnectorName = ref<string | null>(null);
     const suppressWagmiDisconnect = ref(false);
 
+    function getWeb3authConnector() {
+      return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+    }
+
+    function resetConnectorState() {
+      wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+      wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+    }
+    async function disconnectWeb3AuthFromWagmi() {
+      const connector = getWeb3authConnector();
+      await Promise.all([wagmiConfig.storage?.setItem(`${connector?.id}.disconnected`, true), wagmiConfig.storage?.removeItem("injected.connected")]);
+      resetConnectorState();
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId: state.chainId,
+        connections: new Map(),
+        current: undefined,
+        status: "disconnected",
+      }));
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function createWeb3AuthConnector(provider: any): CreateConnectorFn {
+      const baseConnector = injected({
+        target: {
+          provider: provider,
+          id: WEB3AUTH_CONNECTOR_ID,
+          name: "Web3Auth",
+        },
+      });
+
+      return (config) => {
+        const connector = baseConnector(config);
+        const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+        connector.onAccountsChanged = (accounts: string[]) => {
+          // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+          // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+          // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+          if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
+            log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+            return;
+          }
+          baseOnAccountsChanged(accounts);
+        };
+
+        return connector;
+      };
+    }
+
+    // Helper to initialize connectors for the given wallets
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    async function setupConnector(provider: any) {
+      let connector: Connector | CreateConnectorFn = getWeb3authConnector();
+
+      if (connector) return connector;
+
+      // Create new connector if not already existing
+      connector = createWeb3AuthConnector(provider);
+
+      const result = wagmiConfig._internal.connectors.setup(connector);
+      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
+      return result;
+    }
+
+    // Helper to connect a wallet and update wagmi state
+    async function connectWeb3AuthWithWagmi(connector: Connector) {
+      await Promise.all([
+        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
+        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
+      ]);
+
+      let chainId = await connector.getChainId();
+      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
+        chainId = wagmiConfig.chains[0].id;
+      }
+
+      const accounts = await connector.getAccounts();
+
+      const connections: Map<string, Connection> = new Map([
+        [
+          connector.uid,
+          {
+            accounts: [accounts[0]],
+            chainId,
+            connector,
+          },
+        ],
+      ]);
+
+      wagmiConfig.setState((state) => ({
+        ...state,
+        chainId,
+        connections,
+        current: connector.uid,
+        status: "connected",
+      }));
+    }
+
     useConnectionEffect({
       onDisconnect: async () => {
         log.info("Disconnected from wagmi");
@@ -113,11 +138,11 @@ const Web3AuthWagmiProvider = defineComponent({
         suppressWagmiDisconnect.value = false;
         if (!isSuppressed && isConnected.value) await disconnect();
 
-        const connector = getWeb3authConnector(wagmiConfig);
+        const connector = getWeb3authConnector();
         // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
         // from the connected provider
         if (connector) {
-          resetConnectorState(wagmiConfig);
+          resetConnectorState();
         }
       },
     });
@@ -137,21 +162,21 @@ const Web3AuthWagmiProvider = defineComponent({
             return;
           }
 
-          if (!hasSameBinding && getWeb3authConnector(wagmiConfig)) {
+          if (!hasSameBinding && getWeb3authConnector()) {
             if (wagmiConfig.state.status === "connected") {
               suppressWagmiDisconnect.value = true;
-              await disconnectWeb3AuthFromWagmi(wagmiConfig);
+              await disconnectWeb3AuthFromWagmi();
             } else {
-              resetConnectorState(wagmiConfig);
+              resetConnectorState();
             }
           }
 
-          const connector = await setupConnector(newEth, wagmiConfig);
+          const connector = await setupConnector(newEth);
           if (!connector) {
             throw new Error("Failed to setup connector");
           }
 
-          await connectWeb3AuthWithWagmi(connector, wagmiConfig);
+          await connectWeb3AuthWithWagmi(connector);
           lastSyncedProvider.value = newEth;
           lastSyncedConnectorName.value = newConnection.connectorName;
           reconnect();
@@ -160,9 +185,9 @@ const Web3AuthWagmiProvider = defineComponent({
           lastSyncedConnectorName.value = null;
           if (wagmiConfig.state.status === "connected") {
             suppressWagmiDisconnect.value = true;
-            await disconnectWeb3AuthFromWagmi(wagmiConfig);
-          } else if (getWeb3authConnector(wagmiConfig)) {
-            resetConnectorState(wagmiConfig);
+            await disconnectWeb3AuthFromWagmi();
+          } else if (getWeb3authConnector()) {
+            resetConnectorState();
           }
         }
       },

--- a/packages/no-modal/src/vue/wagmi/provider.ts
+++ b/packages/no-modal/src/vue/wagmi/provider.ts
@@ -12,14 +12,108 @@ import { randomId } from "@web3auth/auth";
 import { type Chain, defineChain, fallback, http, isAddress as isEvmAddress, webSocket } from "viem";
 import { defineComponent, h, PropType, provide, ref, shallowRef, watch } from "vue";
 
-import { CHAIN_NAMESPACES, type CustomChainConfig, WalletInitializationError } from "../../base";
+import { CHAIN_NAMESPACES, type CustomChainConfig, WalletInitializationError, WEB3AUTH_CONNECTOR_ID } from "../../base";
 import { log } from "../../base/loglevel";
 // import type { Config, Connection, Connector, CreateConfigParameters, CreateConnectorFn } from "wagmi";
 import { useWeb3Auth, useWeb3AuthDisconnect } from "../composables";
 import { defaultWagmiConfig } from "./constants";
 import { WagmiProviderProps } from "./interface";
 
-const WEB3AUTH_CONNECTOR_ID = "web3auth";
+export function getWeb3authConnector(config: Config) {
+  return config.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
+}
+
+// Helper to create a Web3Auth connector to connect with wagmi
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function createWeb3AuthConnectorForWagmi(provider: any): CreateConnectorFn {
+  const baseConnector = injected({
+    target: {
+      provider: provider,
+      id: WEB3AUTH_CONNECTOR_ID,
+      name: "Web3Auth",
+    },
+  });
+
+  return (config) => {
+    const connector = baseConnector(config);
+    const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
+
+    connector.onAccountsChanged = (accounts: string[]) => {
+      // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
+      // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
+      // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
+      if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
+        log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
+        return;
+      }
+      baseOnAccountsChanged(accounts);
+    };
+
+    return connector;
+  };
+}
+
+// Helper to initialize connectors for the given wallets
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function setupConnector(provider: any, config: Config, connector?: Connector): Connector {
+  if (connector) return connector;
+
+  // Create new connector if not already existing
+  const web3AuthConnector = createWeb3AuthConnectorForWagmi(provider);
+
+  const result = config._internal.connectors.setup(web3AuthConnector);
+  config._internal.connectors.setState((current) => [...current, result]);
+  return result;
+}
+
+// Helper to connect a wallet and update wagmi state
+export async function connectWeb3AuthWithWagmi(connector: Connector, config: Config) {
+  await Promise.all([config.storage?.removeItem(`${connector.id}.disconnected`), config.storage?.setItem("recentConnectorId", connector.id)]);
+
+  let chainId = await connector.getChainId();
+  if (!config.chains.find((c) => c.id === chainId)) {
+    chainId = config.chains[0].id;
+  }
+
+  const accounts = await connector.getAccounts();
+
+  const connections: Map<string, Connection> = new Map([
+    [
+      connector.uid,
+      {
+        accounts: [accounts[0]],
+        chainId,
+        connector,
+      },
+    ],
+  ]);
+
+  config.setState((state) => ({
+    ...state,
+    chainId,
+    connections,
+    current: connector.uid,
+    status: "connected",
+  }));
+}
+
+export function resetConnectorState(config: Config) {
+  config._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
+  config.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
+}
+
+export async function disconnectWeb3AuthFromWagmi(config: Config) {
+  const connector = getWeb3authConnector(config);
+  await Promise.all([config.storage?.setItem(`${connector?.id}.disconnected`, true), config.storage?.removeItem("injected.connected")]);
+  resetConnectorState(config);
+  config.setState((state) => ({
+    ...state,
+    chainId: state.chainId,
+    connections: new Map(),
+    current: undefined,
+    status: "disconnected",
+  }));
+}
 
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
@@ -32,105 +126,6 @@ const Web3AuthWagmiProvider = defineComponent({
     const lastSyncedConnectorName = ref<string | null>(null);
     const suppressWagmiDisconnect = ref(false);
 
-    function getWeb3authConnector() {
-      return wagmiConfig.connectors.find((c) => c.id === WEB3AUTH_CONNECTOR_ID);
-    }
-
-    function resetConnectorState() {
-      wagmiConfig._internal.connectors.setState((prev) => prev.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID));
-      wagmiConfig.connectors.filter((c) => c.id !== WEB3AUTH_CONNECTOR_ID);
-    }
-    async function disconnectWeb3AuthFromWagmi() {
-      const connector = getWeb3authConnector();
-      await Promise.all([wagmiConfig.storage?.setItem(`${connector?.id}.disconnected`, true), wagmiConfig.storage?.removeItem("injected.connected")]);
-      resetConnectorState();
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId: state.chainId,
-        connections: new Map(),
-        current: undefined,
-        status: "disconnected",
-      }));
-    }
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function createWeb3AuthConnector(provider: any): CreateConnectorFn {
-      const baseConnector = injected({
-        target: {
-          provider: provider,
-          id: WEB3AUTH_CONNECTOR_ID,
-          name: "Web3Auth",
-        },
-      });
-
-      return (config) => {
-        const connector = baseConnector(config);
-        const baseOnAccountsChanged = connector.onAccountsChanged.bind(connector);
-
-        connector.onAccountsChanged = (accounts: string[]) => {
-          // we need to handle the `accountsChanged` event emitted on the cross-namespace chain switch.
-          // on evm -> solana, the accountsChanged event is emitted with the solana address, which is not valid for evm.
-          // that causes the `invalid account address` error in wagmi. So, here, we're filtering out the solana addresses.
-          if (accounts.length > 0 && !accounts.every((account) => typeof account === "string" && isEvmAddress(account))) {
-            log.warn("onAccountsChanged::accountsChanged event received on non-EVM address");
-            return;
-          }
-          baseOnAccountsChanged(accounts);
-        };
-
-        return connector;
-      };
-    }
-
-    // Helper to initialize connectors for the given wallets
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    async function setupConnector(provider: any) {
-      let connector: Connector | CreateConnectorFn = getWeb3authConnector();
-
-      if (connector) return connector;
-
-      // Create new connector if not already existing
-      connector = createWeb3AuthConnector(provider);
-
-      const result = wagmiConfig._internal.connectors.setup(connector);
-      wagmiConfig._internal.connectors.setState((current) => [...current, result]);
-      return result;
-    }
-
-    // Helper to connect a wallet and update wagmi state
-    async function connectWeb3AuthWithWagmi(connector: Connector) {
-      await Promise.all([
-        wagmiConfig.storage?.removeItem(`${connector.id}.disconnected`),
-        wagmiConfig.storage?.setItem("recentConnectorId", connector.id),
-      ]);
-
-      let chainId = await connector.getChainId();
-      if (!wagmiConfig.chains.find((c) => c.id === chainId)) {
-        chainId = wagmiConfig.chains[0].id;
-      }
-
-      const accounts = await connector.getAccounts();
-
-      const connections: Map<string, Connection> = new Map([
-        [
-          connector.uid,
-          {
-            accounts: [accounts[0]],
-            chainId,
-            connector,
-          },
-        ],
-      ]);
-
-      wagmiConfig.setState((state) => ({
-        ...state,
-        chainId,
-        connections,
-        current: connector.uid,
-        status: "connected",
-      }));
-    }
-
     useConnectionEffect({
       onDisconnect: async () => {
         log.info("Disconnected from wagmi");
@@ -138,11 +133,11 @@ const Web3AuthWagmiProvider = defineComponent({
         suppressWagmiDisconnect.value = false;
         if (!isSuppressed && isConnected.value) await disconnect();
 
-        const connector = getWeb3authConnector();
+        const connector = getWeb3authConnector(wagmiConfig);
         // reset wagmi connector state if the provider handles disconnection because of the accountsChanged event
         // from the connected provider
         if (connector) {
-          resetConnectorState();
+          resetConnectorState(wagmiConfig);
         }
       },
     });
@@ -154,6 +149,7 @@ const Web3AuthWagmiProvider = defineComponent({
         const newConnection = connection.value;
         const newEth = newConnection?.ethereumProvider ?? null;
         const shouldBindToWagmi = newIsConnected && chainNamespace.value === CHAIN_NAMESPACES.EIP155 && Boolean(newConnection && newEth);
+        const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
 
         if (shouldBindToWagmi && newConnection && newEth) {
           const hasSameBinding = lastSyncedProvider.value === newEth && lastSyncedConnectorName.value === newConnection.connectorName;
@@ -162,21 +158,21 @@ const Web3AuthWagmiProvider = defineComponent({
             return;
           }
 
-          if (!hasSameBinding && getWeb3authConnector()) {
+          if (!hasSameBinding && w3aWagmiConnector) {
             if (wagmiConfig.state.status === "connected") {
               suppressWagmiDisconnect.value = true;
-              await disconnectWeb3AuthFromWagmi();
+              await disconnectWeb3AuthFromWagmi(wagmiConfig);
             } else {
-              resetConnectorState();
+              resetConnectorState(wagmiConfig);
             }
           }
 
-          const connector = await setupConnector(newEth);
+          const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
           if (!connector) {
             throw new Error("Failed to setup connector");
           }
 
-          await connectWeb3AuthWithWagmi(connector);
+          await connectWeb3AuthWithWagmi(connector, wagmiConfig);
           lastSyncedProvider.value = newEth;
           lastSyncedConnectorName.value = newConnection.connectorName;
           reconnect();
@@ -185,9 +181,9 @@ const Web3AuthWagmiProvider = defineComponent({
           lastSyncedConnectorName.value = null;
           if (wagmiConfig.state.status === "connected") {
             suppressWagmiDisconnect.value = true;
-            await disconnectWeb3AuthFromWagmi();
-          } else if (getWeb3authConnector()) {
-            resetConnectorState();
+            await disconnectWeb3AuthFromWagmi(wagmiConfig);
+          } else if (w3aWagmiConnector) {
+            resetConnectorState(wagmiConfig);
           }
         }
       },

--- a/packages/no-modal/src/vue/wagmi/provider.ts
+++ b/packages/no-modal/src/vue/wagmi/provider.ts
@@ -119,7 +119,7 @@ export async function disconnectWeb3AuthFromWagmi(config: Config) {
 const Web3AuthWagmiProvider = defineComponent({
   name: "Web3AuthWagmiProvider",
   setup() {
-    const { isConnected, connection, chainNamespace } = useWeb3Auth();
+    const { isConnected, connection, web3Auth, chainNamespace } = useWeb3Auth();
     const { disconnect } = useWeb3AuthDisconnect();
     const wagmiConfig = useWagmiConfig();
     const { mutate: reconnect } = useReconnect();
@@ -153,7 +153,10 @@ const Web3AuthWagmiProvider = defineComponent({
         const w3aWagmiConnector = getWeb3authConnector(wagmiConfig);
 
         if (shouldBindToWagmi && newConnection && newEth) {
-          const hasSameBinding = lastSyncedProvider.value === newEth && lastSyncedConnectorName.value === newConnection.connectorName;
+          const hasSameBinding =
+            lastSyncedProvider.value === newEth &&
+            lastSyncedConnectorName.value === newConnection.connectorName &&
+            newConnection?.connectorName === web3Auth.value?.primaryConnectorName;
 
           if (hasSameBinding && wagmiConfig.state.status === "connected") {
             return;
@@ -177,7 +180,7 @@ const Web3AuthWagmiProvider = defineComponent({
           lastSyncedProvider.value = newEth;
           lastSyncedConnectorName.value = newConnection.connectorName;
           reconnect();
-        } else {
+        } else if (!newIsConnected || chainNamespace.value !== CHAIN_NAMESPACES.EIP155) {
           lastSyncedProvider.value = null;
           lastSyncedConnectorName.value = null;
           if (wagmiConfig.state.status === "connected") {

--- a/packages/no-modal/src/vue/wagmi/provider.ts
+++ b/packages/no-modal/src/vue/wagmi/provider.ts
@@ -55,13 +55,14 @@ export function createWeb3AuthConnectorForWagmi(provider: any): CreateConnectorF
 
 // Helper to initialize connectors for the given wallets
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function setupConnector(provider: any, config: Config, connector?: Connector): Connector {
+export function setupConnector(provider: any, config: Config): Connector {
+  let connector: Connector | CreateConnectorFn = getWeb3authConnector(config);
   if (connector) return connector;
 
   // Create new connector if not already existing
-  const web3AuthConnector = createWeb3AuthConnectorForWagmi(provider);
+  connector = createWeb3AuthConnectorForWagmi(provider);
 
-  const result = config._internal.connectors.setup(web3AuthConnector);
+  const result = config._internal.connectors.setup(connector);
   config._internal.connectors.setState((current) => [...current, result]);
   return result;
 }
@@ -167,7 +168,7 @@ const Web3AuthWagmiProvider = defineComponent({
             }
           }
 
-          const connector = setupConnector(newEth, wagmiConfig, w3aWagmiConnector);
+          const connector = setupConnector(newEth, wagmiConfig);
           if (!connector) {
             throw new Error("Failed to setup connector");
           }


### PR DESCRIPTION
## Jira Link

https://consensyssoftware.atlassian.net/browse/EMBED-363

## Description

Fixes a wagmi integration issue that occurs when switching from an EVM chain to a non-EVM namespace such as Solana.

Previously, the provider could emit an `accountsChanged` event containing a non-EVM address during a cross-namespace switch. That value was passed through to wagmi, which then threw an `invalid account address` error and left the EVM connection state in a bad state.

This change fixes that by:
- Filtering out non-EVM `accountsChanged` payloads inside the shared Web3Auth wagmi connector
- Centralizing shared wagmi connector setup/connect/disconnect helpers in `@web3auth/no-modal`
- Updating modal React and Vue wagmi providers to reuse the shared no-modal helpers instead of maintaining duplicated logic
- Syncing/binding wagmi only when the active chain namespace is `EIP155`
- Tearing down the Web3Auth wagmi connector when disconnected or when switching to a non-EVM namespace

## How has this been tested?

- Manually verified wagmi behavior when switching across namespaces
- Confirmed that switching from EVM to non-EVM no longer forwards invalid addresses into wagmi
- Confirmed wagmi state is reset/cleaned up when leaving `EIP155`

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Refactor (shared wagmi logic moved into `@web3auth/no-modal`)

## Risk

Medium risk. This updates the Web3Auth <-> wagmi binding flow and connector lifecycle for React/Vue modal and no-modal integrations. Scope is limited to wagmi bridge behavior, but regressions could affect EVM connection state during connect/disconnect or chain namespace switches.

## Checklist

- [x] My code follows the code style of this project
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Web3Auth–wagmi binding and connector lifecycle for React/Vue modal and no-modal; regressions could affect EVM connection state on connect, disconnect, or namespace switches.
> 
> **Overview**
> Fixes cross-namespace chain switches (e.g. EVM → Solana) breaking wagmi by **ignoring non-EVM `accountsChanged` payloads** in a shared injected connector wrapper, so wagmi no longer receives invalid addresses.
> 
> **Shared wagmi bridge** logic (`setup` / connect / disconnect / reset, `WEB3AUTH_CONNECTOR_ID`) moves into `@web3auth/no-modal` and is **re-exported** for React and Vue. Modal wagmi providers **drop duplicated helpers** and call the shared APIs instead.
> 
> **Binding rules** are tightened: wagmi sync runs only when connected on **`EIP155`**, the active connection matches the **primary connector**, and programmatic wagmi teardown uses a **suppress flag** so it does not cascade into a full Web3Auth disconnect. Leaving EVM or disconnecting **cleans up** the Web3Auth wagmi connector state.
> 
> Lockfile bumps `@web3auth/modal` / `@web3auth/no-modal` to **11.0.0-beta.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c812b509d8e490e0e75872a55c25ba220dbd62f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->