### PR TITLE
fix: metamask connector and rehydration

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -50,13 +50,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.8.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.0",
-        "@web3auth/no-modal": "^11.0.0-beta.1",
+        "@web3auth/no-modal": "^11.0.0-beta.2",
         "@web3auth/ws-embed": "^6.0.4",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",
@@ -134,7 +134,7 @@
     },
     "../../packages/no-modal": {
       "name": "@web3auth/no-modal",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
         "@metamask/connect-evm": "^1.3.0",

--- a/demo/vue-app-new/src/components/AppDashboard.vue
+++ b/demo/vue-app-new/src/components/AppDashboard.vue
@@ -452,7 +452,11 @@ const onSwitchChainNamespace = async () => {
             {{ isMFAEnabled ? "Manage MFA" : "Enable MFA" }}
           </Button>
         </div>
-        <AccountLinkingSection :show-link-wallet="isDisplay('walletServices')" :print-to-console="printToConsole" />
+        <AccountLinkingSection
+          v-if="web3Auth?.primaryConnectorName === WALLET_CONNECTORS.AUTH"
+          :show-link-wallet="isDisplay('walletServices')"
+          :print-to-console="printToConsole"
+        />
         <!-- Wallet Services -->
         <Card v-if="isDisplay('walletServices')" class="!h-auto lg:!h-[calc(100dvh_-_240px)] gap-4 px-4 py-4 mb-2" :shadow="false">
           <div class="mb-2 text-xl font-bold leading-tight text-left">Wallet Service</div>

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -227,35 +227,20 @@ class MetaMaskConnector extends BaseConnector<void> {
     }
 
     const coreStatus = this.multichainClient.status;
-    if (coreStatus === "connected") {
+    // only connect if the multichain client is connected and autoConnect is true (i.e during the rehydration)
+    if (coreStatus === "connected" && options.autoConnect) {
       this.status = CONNECTOR_STATUS.CONNECTED;
-
       this.rehydrated = true;
-
-      if (options.autoConnect) {
-        this.emit(CONNECTOR_EVENTS.CONNECTED, {
-          connectorName: WALLET_CONNECTORS.METAMASK,
-          reconnected: this.rehydrated,
-          ethereumProvider: this.evmProvider,
-          solanaWallet: this.solanaProvider,
-        } as CONNECTED_EVENT_DATA);
-
-        if (options.getAuthTokenInfo) {
-          await this.getAuthTokenInfo();
-        }
-      }
-    } else if (coreStatus === "loaded" || coreStatus === "disconnected") {
+      this.emit(CONNECTOR_EVENTS.CONNECTED, {
+        connectorName: WALLET_CONNECTORS.METAMASK,
+        reconnected: true,
+        ethereumProvider: this.evmProvider,
+        solanaWallet: this.solanaProvider,
+      });
+      if (options.getAuthTokenInfo) await this.getAuthTokenInfo();
+    } else if (coreStatus === "connected" || coreStatus === "loaded" || coreStatus === "disconnected" || coreStatus === "pending") {
       this.status = CONNECTOR_STATUS.READY;
       this.emit(CONNECTOR_EVENTS.READY, WALLET_CONNECTORS.METAMASK);
-    } else if (coreStatus === "pending") {
-      // 'pending' implies that a transport failed to resume the connection
-      // if (options.autoConnect) {
-      //   this.rehydrated = false;
-      //   this.emit(CONNECTOR_EVENTS.REHYDRATION_ERROR, new Error("Failed to resume existing MetaMask Connect session.") as Web3AuthError);
-      // } else {
-      this.status = CONNECTOR_STATUS.READY;
-      this.emit(CONNECTOR_EVENTS.READY, WALLET_CONNECTORS.METAMASK);
-      // }
     } else {
       // Something unexpected happened
       this.status = CONNECTOR_STATUS.ERRORED;

--- a/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
+++ b/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
@@ -179,7 +179,13 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWeb3A
     const authorizedListener = () => {
       setStatus(web3Auth.status);
       if (web3Auth.status === CONNECTOR_STATUS.AUTHORIZED) {
+        setIsInitialized(true);
         setIsConnected(true);
+        // on rehydration, `AUTHORIZED` event can be fired first in `CONNECT_AND_SIGN` mode, before `CONNECTED` event.
+        // Update the connection state here, so that clients can use the connection state immediately.
+        setConnection(web3Auth.connection);
+        setChainId(web3Auth.currentChainId);
+        setChainNamespace(web3Auth.currentChain?.chainNamespace ?? null);
         setIsAuthorized(true);
       }
     };

--- a/packages/no-modal/src/vue/useWeb3AuthInnerContextValue.ts
+++ b/packages/no-modal/src/vue/useWeb3AuthInnerContextValue.ts
@@ -147,9 +147,15 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWatch
 
       const authorizedListener = () => {
         status.value = web3Auth.value!.status;
+        // on rehydration, `AUTHORIZED` event can be fired first in `CONNECT_AND_SIGN` mode, before `CONNECTED` event.
+        // Update the connection state here, so that clients can use the connection state immediately.
         if (web3Auth.value!.status === CONNECTOR_STATUS.AUTHORIZED) {
+          if (!isInitialized.value) isInitialized.value = true;
           isAuthorized.value = true;
           isConnected.value = true;
+          connection.value = web3Auth.value!.connection;
+          chainId.value = web3Auth.value!.currentChainId;
+          chainNamespace.value = web3Auth.value!.currentChain?.chainNamespace ?? null;
         }
       };
 


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->
https://consensyssoftware.atlassian.net/browse/EMBED-361?atlOrigin=eyJpIjoiMzMzZDkyYjdhMmYxNGMyZmEzMGUxOTY3YzUyM2NmMjAiLCJwIjoiaiJ9

## Description

<!-- Describe your changes in detail -->

This PR fixes MetaMask external wallet rehydration issues in `CONNECT_AND_SIGN` flows and aligns shared React/Vue connection state with the SDK lifecycle during restore.

The main fix updates MetaMaskConnector.init() so a resumed MetaMask multichain session is only treated as CONNECTED when autoConnect is running during rehydration. In all other multichainClient.status === "connected" cases, the connector now surfaces as READY instead of emitting CONNECTED too early.

It also fixes a timing gap in the shared React and Vue inner context helpers: during rehydration, AUTHORIZED can be emitted before consumers have received a settled CONNECTED-driven connection update. The hooks/composables now hydrate connection, chainId, and chainNamespace on AUTHORIZED as well, so clients can safely use useWeb3Auth() immediately after restore.

### Issue

The issue caused by incorrect init of MetamaskConnector, i.e only init regardless of the MetamaskMultichainClient status, we should only connect and update the connector status if the autoConnect is true.

During the fix, found another bug in rehydration with CONNECT_AND_SIGN mode, the connector can emit AUTHORIZED after cached auth restoration before app-facing state derived from CONNECTED has fully propagated through the shared context layer.

This led to symptoms like:
- MetaMask connector status appearing inconsistent during refresh
- `useWeb3Auth()` reporting connected/authorized state while connection was still null
- clients hitting issues when calling APIs immediately after restore

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wallet connector init/rehydration and shared React/Vue connection state timing, which can affect login and CONNECT_AND_SIGN flows but is narrowly scoped.
> 
> **Overview**
> Fixes **MetaMask connector** initialization so a resumed MetaMask multichain session is only treated as **connected** when `autoConnect` runs during rehydration; otherwise `connected` / `loaded` / `disconnected` / `pending` surfaces as **READY** instead of emitting **CONNECTED** too early.
> 
> **React and Vue** inner context hooks now sync **connection**, **chainId**, and **chainNamespace** (and initialized state) on the **AUTHORIZED** event when **CONNECT_AND_SIGN** rehydration fires **AUTHORIZED** before **CONNECTED**.
> 
> The Vue demo dashboard only renders **Account Linking** when the primary connector is **AUTH**. Lockfile bumps `@web3auth/modal` / `@web3auth/no-modal` to **11.0.0-beta.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ddf0b6234d759a2ddbd1fced1b975ac04404842. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->