### PR TITLE
fix: modal status changes back to connected during authorizing state

### DIFF
--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -545,6 +545,15 @@ export class LoginModal {
     listener.on(CONNECTOR_EVENTS.CONNECTED, (data: SDK_CONNECTED_EVENT_DATA) => {
       log.debug("connected with connector", data);
       if (data.pendingUserConsent) return;
+      // Don't change the modal status back to CONNECTED during these transitions.
+      // This mirrors the guard in noModal.ts.
+      if (
+        this.modalStatus === MODAL_STATUS.AUTHORIZING ||
+        this.modalStatus === MODAL_STATUS.AUTHORIZED ||
+        this.modalStatus === MODAL_STATUS.CONSENT_REQUIRING
+      ) {
+        return;
+      }
       // only show success if not being reconnected again.
       if (!data.reconnected && data.loginMode === LOGIN_MODE.MODAL) {
         this.setState({


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->
https://consensyssoftware.atlassian.net/browse/EMBED-372
https://consensyssoftware.atlassian.net/browse/EMBED-373

## Description
Fixes an issue where the modal status was incorrectly reverting back to `CONNECTED` while the connector was still in an `AUTHORIZING` / `AUTHORIZED` / `CONSENT_REQUIRING` flow. This results on showing and empty modal.

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)
### MetaMask - Connect and Sign (disabled requiredConsent)

https://github.com/user-attachments/assets/ad73fd84-e957-488e-b210-6a9d07dd4986



### MetaMask - Connect only (disabled requiredConsent)

https://github.com/user-attachments/assets/a4f08f75-6d47-4566-8d69-9c08043b39be




### Google (disabled requiredConsent)

https://github.com/user-attachments/assets/3b88a138-9b1d-462c-b515-2ec7682ec5cf



<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early-return guard in the modal CONNECTED listener; no auth or connector logic changes.
> 
> **Overview**
> Fixes a **modal UI regression** where a late `CONNECTED` connector event could reset the widget to **CONNECTED** while the user was still in **authorizing**, **authorized**, or **consent** flows—leaving an **empty modal**.
> 
> The `CONNECTOR_EVENTS.CONNECTED` handler in `loginModal.tsx` now **bails out** when `modalStatus` is already `AUTHORIZING`, `AUTHORIZED`, or `CONSENT_REQUIRING`, matching the guard already used in **no-modal** code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08fa8d79e254b2682fbe5b465a33a2592f2953a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->