### PR TITLE
Add analytics.integrationType 'web3auth' to clients

### DIFF
--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -171,6 +171,9 @@ class MetaMaskConnector extends BaseConnector<void> {
         api: { supportedNetworks: caipSupportedNetworks },
         ui,
         debug: this.connectorSettings?.debug,
+        analytics: {
+          integrationType: "web3auth",
+        },
       });
 
       // Listen for QR code URI from the multichain client (for mobile wallet connection)
@@ -198,6 +201,9 @@ class MetaMaskConnector extends BaseConnector<void> {
           api: { supportedNetworks: hexSupportedNetworks },
           ui,
           debug: this.connectorSettings?.debug,
+          analytics: {
+            integrationType: "web3auth",
+          },
         });
 
         this.evmProvider = this.evmClient.getProvider() as unknown as IProvider;
@@ -209,6 +215,9 @@ class MetaMaskConnector extends BaseConnector<void> {
           dapp,
           api: { supportedNetworks: solanaSupportedNetworks },
           skipAutoRegister: true,
+          analytics: {
+            integrationType: "web3auth",
+          },
         });
         this.solanaProvider = this.solanaClient.getWallet();
       }


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

Pass analytics: { integrationType: 'web3auth' } into multichain client initializations in MetaMaskConnector (CAIP/EVM, hex/EVM, and Solana setups). This tags the clients with the Web3Auth integration type for analytics/tracking purposes when the connector initializes providers.

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics metadata only at client init; no auth, connection, or provider behavior changes.
> 
> **Overview**
> **MetaMask connector** now passes `analytics: { integrationType: "web3auth" }` into all three MetaMask Connect SDK entry points during `init`: `createMultichainClient`, `createEVMClient` (when EVM chains exist), and `createSolanaClient` (when Solana chains exist).
> 
> That labels MetaMask SDK–side telemetry as coming through the Web3Auth integration, separate from the connector’s existing Web3Auth `analytics` used for connection lifecycle events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca17e56b51240fa6ffe507af6f4a6a5e19be160. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->