### PR TITLE
fix(no-modal): respect disableAnalytics in MetaMask connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3176,12 +3176,87 @@
       }
     },
     "node_modules/@metamask/analytics": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@metamask/analytics/-/analytics-0.4.0.tgz",
-      "integrity": "sha512-QKjVu8RsbjeSfXXhRLvOVdWJ0jUrVdXFwa4I1VyoI7LapWS6T0apTSjM8nLJKN1NADbpSYm7ctyuTyaHlG/0yA==",
-      "license": "MIT",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@metamask/analytics/-/analytics-0.6.0.tgz",
+      "integrity": "sha512-L250lV3PANTcKqhZkmRV1Obkyddm6JDQvDBuUVAi+7TmPdOVdpavWNXyEh7ErscjwG0z2wiF9Ne0ihK/nCdX0w==",
+      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "openapi-fetch": "^0.13.5"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@metamask/connect-multichain": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@metamask/connect-multichain/-/connect-multichain-0.15.0.tgz",
+      "integrity": "sha512-ufLG7nvmUTHv+xLojCD2jS4tB/fJ2z78k6njGycO3kfsnJSvJhG97mUV/J7iU23Ojfk2tT3obwbhR8QRM16pXg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@metamask/analytics": "^0.6.0",
+        "@metamask/mobile-wallet-protocol-core": "^0.4.0",
+        "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
+        "@metamask/multichain-api-client": "^0.10.1",
+        "@metamask/multichain-ui": "^0.4.1",
+        "@metamask/onboarding": "^1.0.1",
+        "@metamask/rpc-errors": "^7.0.3",
+        "@metamask/utils": "^11.8.1",
+        "@paulmillr/qr": "^0.2.1",
+        "bowser": "^2.11.0",
+        "buffer": "^6.0.3",
+        "cross-fetch": "^4.1.0",
+        "eciesjs": "0.4.17",
+        "eventemitter3": "^5.0.1",
+        "pako": "^2.1.0",
+        "uuid": "^11.1.0",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@react-native-async-storage/async-storage": "^1.23"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@metamask/connect-multichain/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/@metamask/connect-solana": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@metamask/connect-solana/-/connect-solana-1.2.0.tgz",
+      "integrity": "sha512-IaeM5T37nQw6g8mcCr+HIC6JqCCa1Nv7akRQpRAClzzKWH57L9YTeUFA4R1aNowg09CC1AtNXrax5LYkF/u+EA==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@metamask/connect-multichain": "^0.15.0",
+        "@metamask/solana-wallet-standard": "^0.6.0",
+        "@wallet-standard/app": "~1.1.0",
+        "@wallet-standard/base": "^1.1.0"
       },
       "engines": {
         "node": ">=20.19.0"
@@ -35453,9 +35528,9 @@
       "version": "11.0.0-beta.2",
       "license": "ISC",
       "dependencies": {
-        "@metamask/connect-evm": "^1.3.0",
-        "@metamask/connect-multichain": "^0.14.0",
-        "@metamask/connect-solana": "^1.1.0",
+        "@metamask/connect-evm": "^1.4.0",
+        "@metamask/connect-multichain": "^0.15.0",
+        "@metamask/connect-solana": "^1.2.0",
         "@segment/analytics-next": "^1.83.0",
         "@solana/client": "^1.7.0",
         "@solana/kit": "^6.8.0",
@@ -35540,140 +35615,17 @@
       }
     },
     "packages/no-modal/node_modules/@metamask/connect-evm": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@metamask/connect-evm/-/connect-evm-1.3.1.tgz",
-      "integrity": "sha512-PYUtAXdd0o9tmihavjOnY9skr/PzJf7Yo2VsM3635r98+ce2HC/OeLFI2bO7N7gFOCbYU+PtL+2aE9xNJALEFA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/connect-evm/-/connect-evm-1.4.0.tgz",
+      "integrity": "sha512-SX3GDh6UOTFaVDCLU9V5a+UTymz7avxuisRb4wedI/mwfE768XYq3TvLVXVTf52DeeIFmO5pRh8ShabsOsfF5w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@metamask/analytics": "^0.5.0",
-        "@metamask/connect-multichain": "^0.14.0",
+        "@metamask/analytics": "^0.6.0",
+        "@metamask/connect-multichain": "^0.15.0",
         "@metamask/utils": "^11.8.1"
       },
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "packages/no-modal/node_modules/@metamask/connect-evm/node_modules/@metamask/analytics": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@metamask/analytics/-/analytics-0.5.0.tgz",
-      "integrity": "sha512-BXY7frsjCg1eJcxj7DAqFXyrECYspCVC8+inKfTC/IdW5i4wrMFei02VthnRvLjXAUNZ4c/i4NZvL9DT6HxOnw==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "openapi-fetch": "^0.13.5"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "packages/no-modal/node_modules/@metamask/connect-evm/node_modules/@metamask/connect-multichain": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@metamask/connect-multichain/-/connect-multichain-0.14.0.tgz",
-      "integrity": "sha512-G1bOsOBF7Xy269fbiD+zdTX5wv2sAKEICUafOj51TK4uRGIo8vHWuGdqP1sxfrutCRo3SmqjF4mAI9n8UijuFQ==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@metamask/analytics": "^0.5.0",
-        "@metamask/mobile-wallet-protocol-core": "^0.4.0",
-        "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
-        "@metamask/multichain-api-client": "^0.10.1",
-        "@metamask/multichain-ui": "^0.4.1",
-        "@metamask/onboarding": "^1.0.1",
-        "@metamask/rpc-errors": "^7.0.3",
-        "@metamask/utils": "^11.8.1",
-        "@paulmillr/qr": "^0.2.1",
-        "bowser": "^2.11.0",
-        "buffer": "^6.0.3",
-        "cross-fetch": "^4.1.0",
-        "eciesjs": "0.4.17",
-        "eventemitter3": "^5.0.1",
-        "pako": "^2.1.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@react-native-async-storage/async-storage": "^1.23"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-async-storage/async-storage": {
-          "optional": true
-        }
-      }
-    },
-    "packages/no-modal/node_modules/@metamask/connect-multichain": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@metamask/connect-multichain/-/connect-multichain-0.13.0.tgz",
-      "integrity": "sha512-nXIp/tzgoMQ4CzH79EoHP9Wtpxk5h3T+i7ESdDuwLxYhnuQEF2Yc5eSmUkhns/GUDTyRzT33unN6c2GVer5VMw==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@metamask/analytics": "^0.4.0",
-        "@metamask/mobile-wallet-protocol-core": "^0.4.0",
-        "@metamask/mobile-wallet-protocol-dapp-client": "^0.3.0",
-        "@metamask/multichain-api-client": "^0.10.1",
-        "@metamask/multichain-ui": "^0.4.1",
-        "@metamask/onboarding": "^1.0.1",
-        "@metamask/rpc-errors": "^7.0.3",
-        "@metamask/utils": "^11.8.1",
-        "@paulmillr/qr": "^0.2.1",
-        "bowser": "^2.11.0",
-        "buffer": "^6.0.3",
-        "cross-fetch": "^4.1.0",
-        "eciesjs": "0.4.17",
-        "eventemitter3": "^5.0.1",
-        "pako": "^2.1.0",
-        "uuid": "^11.1.0",
-        "ws": "^8.18.3"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      },
-      "peerDependencies": {
-        "@react-native-async-storage/async-storage": "^1.23"
-      },
-      "peerDependenciesMeta": {
-        "@react-native-async-storage/async-storage": {
-          "optional": true
-        }
-      }
-    },
-    "packages/no-modal/node_modules/@metamask/connect-solana": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@metamask/connect-solana/-/connect-solana-1.1.0.tgz",
-      "integrity": "sha512-4g32yw2IdihqDyGtoMftFpoSNCabeNIc/laHbp2eYrmMFJzvkG1+w4bS/b/Tf51EqiAANCjj4LHbMN3Gubd9UQ==",
-      "license": "SEE LICENSE IN LICENSE",
-      "dependencies": {
-        "@metamask/connect-multichain": "^0.13.0",
-        "@metamask/solana-wallet-standard": "^0.6.0",
-        "@wallet-standard/app": "~1.1.0",
-        "@wallet-standard/base": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=20.19.0"
-      }
-    },
-    "packages/no-modal/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     }
   }

--- a/packages/no-modal/package.json
+++ b/packages/no-modal/package.json
@@ -65,9 +65,9 @@
     }
   },
   "dependencies": {
-    "@metamask/connect-evm": "^1.3.0",
-    "@metamask/connect-multichain": "^0.14.0",
-    "@metamask/connect-solana": "^1.1.0",
+    "@metamask/connect-evm": "^1.4.0",
+    "@metamask/connect-multichain": "^0.15.0",
+    "@metamask/connect-solana": "^1.2.0",
     "@segment/analytics-next": "^1.83.0",
     "@solana/client": "^1.7.0",
     "@solana/kit": "^6.8.0",

--- a/packages/no-modal/src/base/connector/interfaces.ts
+++ b/packages/no-modal/src/base/connector/interfaces.ts
@@ -1,4 +1,4 @@
-import { CaipAccountId } from "@metamask/connect-evm";
+import { type CaipAccountId } from "@metamask/connect-evm";
 import type { Wallet } from "@wallet-standard/base";
 import {
   AUTH_CONNECTION_TYPE,

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -173,6 +173,7 @@ class MetaMaskConnector extends BaseConnector<void> {
         debug: this.connectorSettings?.debug,
         analytics: {
           integrationType: "web3auth",
+          enabled: !this.coreOptions.disableAnalytics,
         },
       });
 
@@ -203,6 +204,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           debug: this.connectorSettings?.debug,
           analytics: {
             integrationType: "web3auth",
+            enabled: !this.coreOptions.disableAnalytics,
           },
         });
 
@@ -217,6 +219,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           skipAutoRegister: true,
           analytics: {
             integrationType: "web3auth",
+            enabled: !this.coreOptions.disableAnalytics,
           },
         });
         this.solanaProvider = this.solanaClient.getWallet();

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1,4 +1,4 @@
-import { CaipAccountId } from "@metamask/connect-evm";
+import { type CaipAccountId } from "@metamask/connect-evm";
 import { BUTTON_POSITION, CONFIRMATION_STRATEGY } from "@toruslabs/base-controllers";
 import {
   type AccountAbstractionMultiChainConfig,


### PR DESCRIPTION
## Jira Link

N/A

## Description

MetaMask connector clients (EVM, multichain, and Solana) now pass `analytics.enabled: !coreOptions.disableAnalytics` during initialization, so Web3Auth’s `disableAnalytics` option also disables MetaMask Connect analytics—not only Web3Auth’s own Segment analytics.

Dependency versions in `@web3auth/no-modal` were bumped to expose the `analytics.enabled` flag:

- `@metamask/connect-evm` ^1.4.0
- `@metamask/connect-multichain` ^0.15.0
- `@metamask/connect-solana` ^1.2.0

`CaipAccountId` is imported as a type-only symbol from `@metamask/connect-evm` in `interfaces.ts` and `noModal.ts`.

## How has this been tested?

- `npm run build` in `packages/no-modal` (passes)
- Manual verification still needed:
  - Initialize with `disableAnalytics: true` and connect via MetaMask — confirm MetaMask analytics are not sent
  - Default config — confirm EVM and Solana MetaMask connection still works after dependency bump

## Screenshots (if appropriate)

N/A — no UI changes.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted privacy/analytics wiring and dependency bumps in the MetaMask connector; no auth or payment logic changes.
> 
> **Overview**
> Fixes a gap where **`disableAnalytics`** only turned off Web3Auth’s Segment analytics while MetaMask Connect SDK clients still reported telemetry.
> 
> The MetaMask connector now passes **`analytics.enabled: !coreOptions.disableAnalytics`** when creating the multichain, EVM, and Solana MetaMask Connect clients. **`@web3auth/no-modal`** dependency versions are bumped (`@metamask/connect-evm` ^1.4.0, `connect-multichain` ^0.15.0, `connect-solana` ^1.2.0) so that flag is supported; the lockfile reflects deduplicated MetaMask packages. **`CaipAccountId`** is imported as a type-only symbol in `interfaces.ts` and `noModal.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d6b08c2f16dd7e1b020b1ba3059ce3b00aaea69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->