### PR TITLE
fix: do not support 7702/5792 for 4337 AA accounts

### DIFF
--- a/demo/vite-react-app-solana/package-lock.json
+++ b/demo/vite-react-app-solana/package-lock.json
@@ -27,13 +27,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.0-beta.1",
+      "version": "11.0.0-beta.2",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.8.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.0",
-        "@web3auth/no-modal": "^11.0.0-beta.1",
+        "@web3auth/no-modal": "^11.0.0-beta.2",
         "@web3auth/ws-embed": "^6.0.4",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",

--- a/demo/vue-app-new/src/components/X402Tester.vue
+++ b/demo/vue-app-new/src/components/X402Tester.vue
@@ -4,12 +4,12 @@ import { useSwitchChain } from "@wagmi/vue";
 import { useX402Fetch } from "@web3auth/modal/x402/vue";
 import { useChain, useWeb3Auth } from "@web3auth/modal/vue";
 import { CHAIN_NAMESPACES } from "@web3auth/no-modal";
-import { ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 
 const BASE_SEPOLIA_CHAIN_ID = "0x14a34"; // 84532
 const SOLANA_DEVNET_CHAIN_ID = "0x67"; // 103
 const SOLANA_DEVNET_CAIP_CHAIN_ID = `solana:${Number(SOLANA_DEVNET_CHAIN_ID)}`;
-const DEFAULT_X402_URL = import.meta.env.VITE_APP_X402_TEST_CONTENT_URL || "https://x402.org/protected";
+const DEFAULT_X402_URL = "https://web3auth-dev-demo-x420.sapphire-dev-2-1.authnetwork.dev";
 
 const { isConnected, connection, web3Auth } = useWeb3Auth();
 const { chainId, chainNamespace } = useChain();
@@ -18,6 +18,8 @@ const { fetchWithPayment } = useX402Fetch();
 const emit = defineEmits<{
   (e: "print-to-console", title: string, payload?: unknown): void;
 }>();
+
+const eip155Chains = computed(() => web3Auth.value?.coreOptions.chains?.filter((c) => c.chainNamespace === CHAIN_NAMESPACES.EIP155) || []);
 
 const url = ref(DEFAULT_X402_URL);
 const fetchLoading = ref(false);
@@ -45,9 +47,13 @@ watch(
 const onSwitchToBaseSepolia = async () => {
   fetchLoading.value = true;
   try {
-    await switchChainAsync({ chainId: parseInt(BASE_SEPOLIA_CHAIN_ID, 16) });
+    const newChain = eip155Chains.value.find((c) => c.chainId === BASE_SEPOLIA_CHAIN_ID);
+    if (!newChain) throw new Error(`Unsupported chainId: ${BASE_SEPOLIA_CHAIN_ID}`);
+    const data = await switchChainAsync({ chainId: Number(newChain.chainId) });
+    emit("print-to-console", "switchedChain", { chainId: data.id });
   } catch (err) {
-    emit("print-to-console", "x402 network error", err instanceof Error ? err.message : String(err));
+    console.error("Error", err);
+    emit("print-to-console", "switchedChain error", err instanceof Error ? err.message : String(err));
   } finally {
     fetchLoading.value = false;
   }

--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -378,7 +378,7 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
     });
     if (!citadelUserInfo?.accounts?.length) return [];
 
-    const currentChainNamespace = this.solanaWallet.accounts.length > 0 ? CHAIN_NAMESPACES.SOLANA : "evm"; // Note: citadel chain namespace is "evm" for EVM chains
+    const currentChainNamespace = this.solanaWallet?.accounts.length > 0 ? CHAIN_NAMESPACES.SOLANA : "evm"; // Note: citadel chain namespace is "evm" for EVM chains
     const filteredLinkedAccounts: LinkedAccountInfo[] = [];
     for (const account of citadelUserInfo.accounts) {
       const { chainNamespace, isPrimary, accountType } = account;

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -43,6 +43,7 @@ import {
   getSolanaChainByChainConfig,
   type IProvider,
   isUserRejectedError,
+  type ProviderEvents,
   type UserInfo,
   WALLET_CONNECTOR_TYPE,
   WALLET_CONNECTORS,
@@ -77,6 +78,8 @@ export interface MetaMaskConnectorOptions extends BaseConnectorSettings {
   connectorSettings?: MetaMaskConnectorSettings;
 }
 
+const EVM_PROVIDER_EVENTS = ["accountsChanged", "chainChanged", "connect", "disconnect"] as const satisfies (keyof ProviderEvents)[];
+
 class MetaMaskConnector extends BaseConnector<void> {
   readonly connectorNamespace: ConnectorNamespaceType = CONNECTOR_NAMESPACES.MULTICHAIN;
 
@@ -103,6 +106,8 @@ class MetaMaskConnector extends BaseConnector<void> {
   private connectorSettings?: MetaMaskConnectorSettings;
 
   private analytics?: Analytics;
+
+  private evmProviderEventBridgeRemovers: (() => void)[] = [];
 
   constructor(connectorOptions: MetaMaskConnectorOptions) {
     super(connectorOptions);
@@ -303,7 +308,7 @@ class MetaMaskConnector extends BaseConnector<void> {
         this.emit(CONNECTOR_EVENTS.CONNECTING, { connector: WALLET_CONNECTORS.METAMASK });
 
         const evmConnectedPromise = new Promise<void>((resolve) => {
-          if (this.evmClient.status === "connected") {
+          if (!this.evmClient || this.evmClient.status === "connected") {
             resolve();
           } else {
             // Wait for EVM provider to be ready
@@ -401,6 +406,7 @@ class MetaMaskConnector extends BaseConnector<void> {
       this.initializationPromise = null;
       this.multichainClient = null;
       this.evmClient = null;
+      this.clearEvmProviderEventBridges();
       this.evmProvider = null;
       this.solanaClient = null;
       this.solanaProvider = null;
@@ -584,21 +590,39 @@ class MetaMaskConnector extends BaseConnector<void> {
     const engine = JRPCEngineV2.create({ middleware: [switchChainMiddleware, forwardMiddleware] });
     const engineProvider = providerFromEngineV2(engine) as IProvider;
 
-    return {
-      ...engineProvider,
-      // get the chainId from the original provider (i.e. metamask)
-      get chainId() {
+    // providerFromEngineV2 wraps requests with its own event emitter, while MetaMask
+    // emits wallet state changes on the original provider.
+    // so we need to bridge the events from the original provider to the engine provider
+    this.bridgeProviderEvents(provider, engineProvider);
+
+    Object.defineProperty(engineProvider, "chainId", {
+      configurable: true,
+      enumerable: true,
+      get() {
         return provider.chainId;
       },
-      // bind the provider events to the engine provider
-      // without the binding, the engine provider could not forward events to the original provider
-      on: provider.on.bind(provider),
-      once: provider.once.bind(provider),
-      removeListener: provider.removeListener.bind(provider),
-      off: typeof provider.off === "function" ? provider.off.bind(provider) : undefined,
-      emit: typeof provider.emit === "function" ? provider.emit.bind(provider) : undefined,
-      removeAllListeners: typeof provider.removeAllListeners === "function" ? provider.removeAllListeners.bind(provider) : undefined,
-    } as IProvider;
+    });
+
+    return engineProvider;
+  }
+
+  private bridgeProviderEvents(sourceProvider: IProvider, targetProvider: IProvider): void {
+    // clean up any existing event bridges before creating new ones
+    this.clearEvmProviderEventBridges();
+    this.evmProviderEventBridgeRemovers = EVM_PROVIDER_EVENTS.map((event) => this.bridgeProviderEvent(sourceProvider, targetProvider, event));
+  }
+
+  private bridgeProviderEvent<K extends keyof ProviderEvents>(sourceProvider: IProvider, targetProvider: IProvider, event: K): () => void {
+    const handler = ((...args: Parameters<ProviderEvents[K]>) => {
+      targetProvider.emit(event, ...args);
+    }) as unknown as ProviderEvents[K];
+    sourceProvider.on(event, handler);
+    return () => sourceProvider.removeListener(event, handler);
+  }
+
+  private clearEvmProviderEventBridges(): void {
+    this.evmProviderEventBridgeRemovers.forEach((remove) => remove());
+    this.evmProviderEventBridgeRemovers = [];
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -586,6 +586,10 @@ class MetaMaskConnector extends BaseConnector<void> {
 
     return {
       ...engineProvider,
+      // get the chainId from the original provider (i.e. metamask)
+      get chainId() {
+        return provider.chainId;
+      },
       // bind the provider events to the engine provider
       // without the binding, the engine provider could not forward events to the original provider
       on: provider.on.bind(provider),

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -584,20 +584,7 @@ class MetaMaskConnector extends BaseConnector<void> {
     const engine = JRPCEngineV2.create({ middleware: [switchChainMiddleware, forwardMiddleware] });
     const engineProvider = providerFromEngineV2(engine) as IProvider;
 
-    return {
-      get chainId() {
-        return provider.chainId;
-      },
-      request: engineProvider.request.bind(engineProvider),
-      sendAsync: engineProvider.sendAsync.bind(engineProvider),
-      send: engineProvider.send.bind(engineProvider),
-      on: provider.on.bind(provider),
-      once: provider.once.bind(provider),
-      removeListener: provider.removeListener.bind(provider),
-      off: typeof provider.off === "function" ? provider.off.bind(provider) : undefined,
-      emit: typeof provider.emit === "function" ? provider.emit.bind(provider) : undefined,
-      removeAllListeners: typeof provider.removeAllListeners === "function" ? provider.removeAllListeners.bind(provider) : undefined,
-    } as IProvider;
+    return engineProvider;
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -557,7 +557,7 @@ class MetaMaskConnector extends BaseConnector<void> {
 
   private createEvmProviderBridge(provider: IProvider): IProvider {
     return new Proxy(provider, {
-      get: (target, prop, receiver) => {
+      get: (target, prop) => {
         if (prop === "request") {
           return async <S, R>(args: { method: string; params?: S }) => {
             // handle `wallet_switchEthereumChain` request from the clients which uses the EVM provider directly (e.g. wagmi actions)
@@ -578,7 +578,9 @@ class MetaMaskConnector extends BaseConnector<void> {
           };
         }
 
-        const value = Reflect.get(target, prop, receiver);
+        // Use the original provider as the receiver so SDK getters that rely on
+        // private fields (`#field`) keep the correct brand check context.
+        const value = Reflect.get(target, prop, target);
         return typeof value === "function" ? value.bind(target) : value;
       },
     }) as IProvider;

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -5,15 +5,6 @@ import { getErrorAnalyticsProperties, signChallenge } from "@toruslabs/base-cont
 import { bytesToHexPrefixedString, utf8ToBytes } from "@toruslabs/metadata-helpers";
 import type { Wallet } from "@wallet-standard/base";
 import { StandardConnect, StandardConnectFeature } from "@wallet-standard/features";
-import {
-  createScaffoldMiddlewareV2,
-  JRPCEngineV2,
-  type JRPCRequest,
-  type MiddlewareConstraint,
-  type MiddlewareParams,
-  providerFromEngineV2,
-  rpcErrors,
-} from "@web3auth/auth";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
 import { generateSiweNonce } from "viem/siwe";
 
@@ -43,7 +34,6 @@ import {
   getSolanaChainByChainConfig,
   type IProvider,
   isUserRejectedError,
-  type ProviderEvents,
   type UserInfo,
   WALLET_CONNECTOR_TYPE,
   WALLET_CONNECTORS,
@@ -78,8 +68,6 @@ export interface MetaMaskConnectorOptions extends BaseConnectorSettings {
   connectorSettings?: MetaMaskConnectorSettings;
 }
 
-const EVM_PROVIDER_EVENTS = ["accountsChanged", "chainChanged", "connect", "disconnect"] as const satisfies (keyof ProviderEvents)[];
-
 class MetaMaskConnector extends BaseConnector<void> {
   readonly connectorNamespace: ConnectorNamespaceType = CONNECTOR_NAMESPACES.MULTICHAIN;
 
@@ -106,8 +94,6 @@ class MetaMaskConnector extends BaseConnector<void> {
   private connectorSettings?: MetaMaskConnectorSettings;
 
   private analytics?: Analytics;
-
-  private evmProviderEventBridgeRemovers: (() => void)[] = [];
 
   constructor(connectorOptions: MetaMaskConnectorOptions) {
     super(connectorOptions);
@@ -228,7 +214,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           },
         });
 
-        this.evmProvider = this.createEvmProviderBridge(this.evmClient.getProvider() as unknown as IProvider);
+        this.evmProvider = this.evmClient.getProvider() as unknown as IProvider;
       }
 
       // Create the Solana client only when Solana chains are configured
@@ -308,7 +294,7 @@ class MetaMaskConnector extends BaseConnector<void> {
         this.emit(CONNECTOR_EVENTS.CONNECTING, { connector: WALLET_CONNECTORS.METAMASK });
 
         const evmConnectedPromise = new Promise<void>((resolve) => {
-          if (!this.evmClient || this.evmClient.status === "connected") {
+          if (this.evmClient.status === "connected") {
             resolve();
           } else {
             // Wait for EVM provider to be ready
@@ -406,7 +392,6 @@ class MetaMaskConnector extends BaseConnector<void> {
       this.initializationPromise = null;
       this.multichainClient = null;
       this.evmClient = null;
-      this.clearEvmProviderEventBridges();
       this.evmProvider = null;
       this.solanaClient = null;
       this.solanaProvider = null;
@@ -472,7 +457,24 @@ class MetaMaskConnector extends BaseConnector<void> {
       throw WalletLoginError.unsupportedOperation("switchChain requires an EVM client, but no EVM chains are configured.");
     }
 
-    const chainConfiguration = this.getEvmChainConfiguration(params.chainId);
+    const chainConfig = this.coreOptions.chains.find(
+      (x) => x.chainId === params.chainId && ([CHAIN_NAMESPACES.EIP155] as ChainNamespaceType[]).includes(x.chainNamespace)
+    );
+
+    const chainConfiguration = chainConfig
+      ? {
+          chainId: params.chainId,
+          chainName: chainConfig.displayName,
+          rpcUrls: [chainConfig.rpcTarget],
+          blockExplorerUrls: chainConfig.blockExplorerUrl ? [chainConfig.blockExplorerUrl] : undefined,
+          nativeCurrency: {
+            name: chainConfig.tickerName,
+            symbol: chainConfig.ticker,
+            decimals: chainConfig.decimals || 18,
+          },
+          iconUrls: chainConfig.logo ? [chainConfig.logo] : undefined,
+        }
+      : undefined;
 
     await this.evmClient.switchChain({ chainId: params.chainId as Hex, chainConfiguration });
   }
@@ -547,82 +549,6 @@ class MetaMaskConnector extends BaseConnector<void> {
       throw WalletLoginError.notConnectedError("Connector is not initialized. Call init() first.");
     }
     await this.initializationPromise;
-  }
-
-  private getEvmChainConfiguration(chainId: string) {
-    const chainConfig = this.coreOptions.chains.find(
-      (x) => x.chainId === chainId && ([CHAIN_NAMESPACES.EIP155] as ChainNamespaceType[]).includes(x.chainNamespace)
-    );
-
-    return chainConfig
-      ? {
-          chainId,
-          chainName: chainConfig.displayName,
-          rpcUrls: [chainConfig.rpcTarget],
-          blockExplorerUrls: chainConfig.blockExplorerUrl ? [chainConfig.blockExplorerUrl] : undefined,
-          nativeCurrency: {
-            name: chainConfig.tickerName,
-            symbol: chainConfig.ticker,
-            decimals: chainConfig.decimals || 18,
-          },
-          iconUrls: chainConfig.logo ? [chainConfig.logo] : undefined,
-        }
-      : undefined;
-  }
-
-  private createEvmProviderBridge(provider: IProvider): IProvider {
-    const switchChainMiddleware = createScaffoldMiddlewareV2({
-      wallet_switchEthereumChain: async (params: MiddlewareParams<JRPCRequest<{ chainId: string }[]>>): Promise<null> => {
-        const chainParams = params.request.params?.length ? params.request.params[0] : undefined;
-        const chainId = chainParams?.chainId;
-
-        if (!chainId) throw rpcErrors.invalidParams("Missing chainId");
-        if (!this.evmClient) throw WalletLoginError.unsupportedOperation("MetaMask EVM client is not initialized");
-
-        const chainConfiguration = this.getEvmChainConfiguration(chainId);
-        await this.evmClient.switchChain({ chainId: chainId as Hex, chainConfiguration });
-        return null;
-      },
-    });
-    const forwardMiddleware: MiddlewareConstraint = async ({ request }) => {
-      return provider.request({ method: request.method, params: request.params });
-    };
-    const engine = JRPCEngineV2.create({ middleware: [switchChainMiddleware, forwardMiddleware] });
-    const engineProvider = providerFromEngineV2(engine) as IProvider;
-
-    // providerFromEngineV2 wraps requests with its own event emitter, while MetaMask
-    // emits wallet state changes on the original provider.
-    // so we need to bridge the events from the original provider to the engine provider
-    this.bridgeProviderEvents(provider, engineProvider);
-
-    Object.defineProperty(engineProvider, "chainId", {
-      configurable: true,
-      enumerable: true,
-      get() {
-        return provider.chainId;
-      },
-    });
-
-    return engineProvider;
-  }
-
-  private bridgeProviderEvents(sourceProvider: IProvider, targetProvider: IProvider): void {
-    // clean up any existing event bridges before creating new ones
-    this.clearEvmProviderEventBridges();
-    this.evmProviderEventBridgeRemovers = EVM_PROVIDER_EVENTS.map((event) => this.bridgeProviderEvent(sourceProvider, targetProvider, event));
-  }
-
-  private bridgeProviderEvent<K extends keyof ProviderEvents>(sourceProvider: IProvider, targetProvider: IProvider, event: K): () => void {
-    const handler = ((...args: Parameters<ProviderEvents[K]>) => {
-      targetProvider.emit(event, ...args);
-    }) as unknown as ProviderEvents[K];
-    sourceProvider.on(event, handler);
-    return () => sourceProvider.removeListener(event, handler);
-  }
-
-  private clearEvmProviderEventBridges(): void {
-    this.evmProviderEventBridgeRemovers.forEach((remove) => remove());
-    this.evmProviderEventBridgeRemovers = [];
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -584,7 +584,17 @@ class MetaMaskConnector extends BaseConnector<void> {
     const engine = JRPCEngineV2.create({ middleware: [switchChainMiddleware, forwardMiddleware] });
     const engineProvider = providerFromEngineV2(engine) as IProvider;
 
-    return engineProvider;
+    return {
+      ...engineProvider,
+      // bind the provider events to the engine provider
+      // without the binding, the engine provider could not forward events to the original provider
+      on: provider.on.bind(provider),
+      once: provider.once.bind(provider),
+      removeListener: provider.removeListener.bind(provider),
+      off: typeof provider.off === "function" ? provider.off.bind(provider) : undefined,
+      emit: typeof provider.emit === "function" ? provider.emit.bind(provider) : undefined,
+      removeAllListeners: typeof provider.removeAllListeners === "function" ? provider.removeAllListeners.bind(provider) : undefined,
+    } as IProvider;
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -5,6 +5,15 @@ import { getErrorAnalyticsProperties, signChallenge } from "@toruslabs/base-cont
 import { bytesToHexPrefixedString, utf8ToBytes } from "@toruslabs/metadata-helpers";
 import type { Wallet } from "@wallet-standard/base";
 import { StandardConnect, StandardConnectFeature } from "@wallet-standard/features";
+import {
+  createScaffoldMiddlewareV2,
+  JRPCEngineV2,
+  type JRPCRequest,
+  type MiddlewareConstraint,
+  type MiddlewareParams,
+  providerFromEngineV2,
+  rpcErrors,
+} from "@web3auth/auth";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
 import { generateSiweNonce } from "viem/siwe";
 
@@ -556,34 +565,39 @@ class MetaMaskConnector extends BaseConnector<void> {
   }
 
   private createEvmProviderBridge(provider: IProvider): IProvider {
-    return new Proxy(provider, {
-      get: (target, prop) => {
-        if (prop === "request") {
-          return async <S, R>(args: { method: string; params?: S }) => {
-            // handle `wallet_switchEthereumChain` request from the clients which uses the EVM provider directly (e.g. wagmi actions)
-            // we already handle this method, `wallet_switchEthereumChain` in other connectors, but metamask lacks of this
-            if (args?.method === "wallet_switchEthereumChain") {
-              const chainParams = Array.isArray(args.params) ? args.params[0] : undefined;
-              const chainId =
-                chainParams && typeof chainParams === "object" && "chainId" in chainParams ? (chainParams.chainId as string | undefined) : undefined;
+    const switchChainMiddleware = createScaffoldMiddlewareV2({
+      wallet_switchEthereumChain: async (params: MiddlewareParams<JRPCRequest<{ chainId: string }[]>>): Promise<null> => {
+        const chainParams = params.request.params?.length ? params.request.params[0] : undefined;
+        const chainId = chainParams?.chainId;
 
-              if (chainId && this.evmClient) {
-                const chainConfiguration = this.getEvmChainConfiguration(chainId);
-                await this.evmClient.switchChain({ chainId: chainId as Hex, chainConfiguration });
-                return null as R;
-              }
-            }
+        if (!chainId) throw rpcErrors.invalidParams("Missing chainId");
+        if (!this.evmClient) throw WalletLoginError.unsupportedOperation("MetaMask EVM client is not initialized");
 
-            return target.request(args);
-          };
-        }
-
-        // Use the original provider as the receiver so SDK getters that rely on
-        // private fields (`#field`) keep the correct brand check context.
-        const value = Reflect.get(target, prop, target);
-        return typeof value === "function" ? value.bind(target) : value;
+        const chainConfiguration = this.getEvmChainConfiguration(chainId);
+        await this.evmClient.switchChain({ chainId: chainId as Hex, chainConfiguration });
+        return null;
       },
-    }) as IProvider;
+    });
+    const forwardMiddleware: MiddlewareConstraint = async ({ request }) => {
+      return provider.request({ method: request.method, params: request.params });
+    };
+    const engine = JRPCEngineV2.create({ middleware: [switchChainMiddleware, forwardMiddleware] });
+    const engineProvider = providerFromEngineV2(engine) as IProvider;
+
+    return {
+      get chainId() {
+        return provider.chainId;
+      },
+      request: engineProvider.request.bind(engineProvider),
+      sendAsync: engineProvider.sendAsync.bind(engineProvider),
+      send: engineProvider.send.bind(engineProvider),
+      on: provider.on.bind(provider),
+      once: provider.once.bind(provider),
+      removeListener: provider.removeListener.bind(provider),
+      off: typeof provider.off === "function" ? provider.off.bind(provider) : undefined,
+      emit: typeof provider.emit === "function" ? provider.emit.bind(provider) : undefined,
+      removeAllListeners: typeof provider.removeAllListeners === "function" ? provider.removeAllListeners.bind(provider) : undefined,
+    } as IProvider;
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -214,7 +214,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           },
         });
 
-        this.evmProvider = this.evmClient.getProvider() as unknown as IProvider;
+        this.evmProvider = this.createEvmProviderBridge(this.evmClient.getProvider() as unknown as IProvider);
       }
 
       // Create the Solana client only when Solana chains are configured
@@ -457,24 +457,7 @@ class MetaMaskConnector extends BaseConnector<void> {
       throw WalletLoginError.unsupportedOperation("switchChain requires an EVM client, but no EVM chains are configured.");
     }
 
-    const chainConfig = this.coreOptions.chains.find(
-      (x) => x.chainId === params.chainId && ([CHAIN_NAMESPACES.EIP155] as ChainNamespaceType[]).includes(x.chainNamespace)
-    );
-
-    const chainConfiguration = chainConfig
-      ? {
-          chainId: params.chainId,
-          chainName: chainConfig.displayName,
-          rpcUrls: [chainConfig.rpcTarget],
-          blockExplorerUrls: chainConfig.blockExplorerUrl ? [chainConfig.blockExplorerUrl] : undefined,
-          nativeCurrency: {
-            name: chainConfig.tickerName,
-            symbol: chainConfig.ticker,
-            decimals: chainConfig.decimals || 18,
-          },
-          iconUrls: chainConfig.logo ? [chainConfig.logo] : undefined,
-        }
-      : undefined;
+    const chainConfiguration = this.getEvmChainConfiguration(params.chainId);
 
     await this.evmClient.switchChain({ chainId: params.chainId as Hex, chainConfiguration });
   }
@@ -549,6 +532,56 @@ class MetaMaskConnector extends BaseConnector<void> {
       throw WalletLoginError.notConnectedError("Connector is not initialized. Call init() first.");
     }
     await this.initializationPromise;
+  }
+
+  private getEvmChainConfiguration(chainId: string) {
+    const chainConfig = this.coreOptions.chains.find(
+      (x) => x.chainId === chainId && ([CHAIN_NAMESPACES.EIP155] as ChainNamespaceType[]).includes(x.chainNamespace)
+    );
+
+    return chainConfig
+      ? {
+          chainId,
+          chainName: chainConfig.displayName,
+          rpcUrls: [chainConfig.rpcTarget],
+          blockExplorerUrls: chainConfig.blockExplorerUrl ? [chainConfig.blockExplorerUrl] : undefined,
+          nativeCurrency: {
+            name: chainConfig.tickerName,
+            symbol: chainConfig.ticker,
+            decimals: chainConfig.decimals || 18,
+          },
+          iconUrls: chainConfig.logo ? [chainConfig.logo] : undefined,
+        }
+      : undefined;
+  }
+
+  private createEvmProviderBridge(provider: IProvider): IProvider {
+    return new Proxy(provider, {
+      get: (target, prop, receiver) => {
+        if (prop === "request") {
+          return async <S, R>(args: { method: string; params?: S }) => {
+            // handle `wallet_switchEthereumChain` request from the clients which uses the EVM provider directly (e.g. wagmi actions)
+            // we already handle this method, `wallet_switchEthereumChain` in other connectors, but metamask lacks of this
+            if (args?.method === "wallet_switchEthereumChain") {
+              const chainParams = Array.isArray(args.params) ? args.params[0] : undefined;
+              const chainId =
+                chainParams && typeof chainParams === "object" && "chainId" in chainParams ? (chainParams.chainId as string | undefined) : undefined;
+
+              if (chainId && this.evmClient) {
+                const chainConfiguration = this.getEvmChainConfiguration(chainId);
+                await this.evmClient.switchChain({ chainId: chainId as Hex, chainConfiguration });
+                return null as R;
+              }
+            }
+
+            return target.request(args);
+          };
+        }
+
+        const value = Reflect.get(target, prop, receiver);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    }) as IProvider;
   }
 }
 

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -2,8 +2,6 @@ import {
   type AccountAbstractionMultiChainConfig,
   type BiconomySmartAccountConfig,
   type BundlerConfig,
-  EIP_5792_METHODS,
-  EIP_7702_METHODS,
   type ISmartAccount,
   type KernelSmartAccountConfig,
   type MetamaskSmartAccountConfig,
@@ -20,7 +18,7 @@ import { type BundlerClient, createBundlerClient, createPaymasterClient, type Pa
 
 import { CHAIN_NAMESPACES, type CustomChainConfig, type IProvider, WalletInitializationError } from "../../../base";
 import { BaseProvider, type BaseProviderConfig, type BaseProviderState } from "../../../providers/base-provider";
-import { createAaMiddleware, createEoaMiddleware, providerAsMiddleware } from "../rpc/ethRpcMiddlewares";
+import { createAaMiddleware, createEip7702And5792MiddlewareForAaProvider, createEoaMiddleware, providerAsMiddleware } from "../rpc/ethRpcMiddlewares";
 import { getProviderHandlers } from "./utils";
 
 interface AccountAbstractionProviderConfig extends BaseProviderConfig {
@@ -82,10 +80,9 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
   }
 
   public async setupProvider(eoaProvider: IProvider): Promise<void> {
-    const currentChain = this.currentChain;
-    const chainNamespace = currentChain?.chainNamespace;
-    if (chainNamespace && chainNamespace !== this.PROVIDER_CHAIN_NAMESPACE)
-      throw WalletInitializationError.incompatibleChainNameSpace("Invalid chain namespace");
+    const { currentChain } = this;
+    const { chainNamespace } = currentChain;
+    if (chainNamespace !== this.PROVIDER_CHAIN_NAMESPACE) throw WalletInitializationError.incompatibleChainNameSpace("Invalid chain namespace");
     const bundlerAndPaymasterConfig = this.config.smartAccountChainsConfig.find((config) => config.chainId === currentChain.chainId);
     if (!bundlerAndPaymasterConfig)
       throw WalletInitializationError.invalidProviderConfigError(`Bundler and paymaster config not found for chain ${currentChain.chainId}`);
@@ -158,19 +155,11 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
       handlers: providerHandlers,
     });
 
-    // override EIP-5792 and EIP-7702 methods to throw unsupported method error
-    // 4437 AA Account will not support the EIP7702/5792 methods
-    const overrideEip5792And7702MethodsHandlers = Object.fromEntries(
-      [...Object.values(EIP_5792_METHODS), ...Object.values(EIP_7702_METHODS)].map((method) => [
-        method,
-        async () => {
-          throw providerErrors.unsupportedMethod(`${method} is not supported for account abstraction provider`);
-        },
-      ])
-    );
-
-    const eoaMiddleware = providerAsMiddleware(eoaProvider, overrideEip5792And7702MethodsHandlers);
-    const engine = JRPCEngineV2.create({ middleware: [aaMiddleware, eoaMiddleware] });
+    // middleware to handle EIP-7702 and EIP-5792 methods,
+    // currently, we do not support EIP-7702 and EIP-5792 methods for account abstraction provider
+    const eip7702And5792Middleware = await createEip7702And5792MiddlewareForAaProvider();
+    const eoaMiddleware = providerAsMiddleware(eoaProvider);
+    const engine = JRPCEngineV2.create({ middleware: [aaMiddleware, eip7702And5792Middleware, eoaMiddleware] });
     const provider = providerFromEngineV2(engine);
     this.updateProviderEngineProxy(provider);
     eoaProvider.once("chainChanged", (chainId) => {

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -82,9 +82,10 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
   }
 
   public async setupProvider(eoaProvider: IProvider): Promise<void> {
-    const { currentChain } = this;
-    const { chainNamespace } = currentChain;
-    if (chainNamespace !== this.PROVIDER_CHAIN_NAMESPACE) throw WalletInitializationError.incompatibleChainNameSpace("Invalid chain namespace");
+    const currentChain = this.currentChain;
+    const chainNamespace = currentChain?.chainNamespace;
+    if (chainNamespace && chainNamespace !== this.PROVIDER_CHAIN_NAMESPACE)
+      throw WalletInitializationError.incompatibleChainNameSpace("Invalid chain namespace");
     const bundlerAndPaymasterConfig = this.config.smartAccountChainsConfig.find((config) => config.chainId === currentChain.chainId);
     if (!bundlerAndPaymasterConfig)
       throw WalletInitializationError.invalidProviderConfigError(`Bundler and paymaster config not found for chain ${currentChain.chainId}`);

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -80,7 +80,10 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
   }
 
   public async setupProvider(eoaProvider: IProvider): Promise<void> {
-    const { currentChain } = this;
+    const currentChain = this.currentChain;
+    if (!currentChain) {
+      throw WalletInitializationError.invalidProviderConfigError(`AA chain config not found for chain ${this.chainId}`);
+    }
     const { chainNamespace } = currentChain;
     if (chainNamespace !== this.PROVIDER_CHAIN_NAMESPACE) throw WalletInitializationError.incompatibleChainNameSpace("Invalid chain namespace");
     const bundlerAndPaymasterConfig = this.config.smartAccountChainsConfig.find((config) => config.chainId === currentChain.chainId);

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -2,6 +2,8 @@ import {
   type AccountAbstractionMultiChainConfig,
   type BiconomySmartAccountConfig,
   type BundlerConfig,
+  EIP_5792_METHODS,
+  EIP_7702_METHODS,
   type ISmartAccount,
   type KernelSmartAccountConfig,
   type MetamaskSmartAccountConfig,
@@ -154,7 +156,19 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
       eoaProvider,
       handlers: providerHandlers,
     });
-    const eoaMiddleware = providerAsMiddleware(eoaProvider);
+
+    // override EIP-5792 and EIP-7702 methods to throw unsupported method error
+    // 4437 AA Account will not support the EIP7702/5792 methods
+    const overrideEip5792And7702MethodsHandlers = Object.fromEntries(
+      [...Object.values(EIP_5792_METHODS), ...Object.values(EIP_7702_METHODS)].map((method) => [
+        method,
+        async () => {
+          throw providerErrors.unsupportedMethod(`${method} is not supported for account abstraction provider`);
+        },
+      ])
+    );
+
+    const eoaMiddleware = providerAsMiddleware(eoaProvider, overrideEip5792And7702MethodsHandlers);
     const engine = JRPCEngineV2.create({ middleware: [aaMiddleware, eoaMiddleware] });
     const provider = providerFromEngineV2(engine);
     this.updateProviderEngineProxy(provider);

--- a/packages/no-modal/src/providers/account-abstraction-provider/rpc/ethRpcMiddlewares.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/rpc/ethRpcMiddlewares.ts
@@ -1,5 +1,13 @@
 import { METHOD_TYPES } from "@toruslabs/ethereum-controllers";
-import { createScaffoldMiddlewareV2, type JRPCRequest, type MiddlewareConstraint, type MiddlewareParams, rpcErrors } from "@web3auth/auth";
+import {
+  cloneDeep,
+  createScaffoldMiddlewareV2,
+  type JRPCRequest,
+  Json,
+  type MiddlewareConstraint,
+  type MiddlewareParams,
+  rpcErrors,
+} from "@web3auth/auth";
 
 import { IProvider } from "../../../base";
 import { IEthProviderHandlers, MessageParams, TransactionParams, TypedMessageParams } from "../../ethereum-provider";
@@ -210,8 +218,29 @@ export async function createEoaMiddleware({ aaProvider }: { aaProvider: IProvide
   });
 }
 
-export function providerAsMiddleware(provider: IProvider): MiddlewareConstraint {
+/**
+ * Creates a middleware that forwards the request to the given provider.
+ *
+ * If `overrideHandlers` is provided, the middleware will check if the request method is in the `overrideHandlers` object.
+ * If it is, the middleware will call the handler function with the request and return the result.
+ * If it is not, the middleware will forward the request to the given provider.
+ *
+ * @param provider - The provider to use.
+ * @param overrideHandlers - The handlers to override.
+ * @returns The middleware.
+ */
+export function providerAsMiddleware(
+  provider: IProvider,
+  overrideHandlers?: Record<string, (request: JRPCRequest<unknown>) => Promise<unknown>>
+): MiddlewareConstraint {
   return async ({ request }) => {
+    if (overrideHandlers) {
+      const handler = overrideHandlers[request.method as keyof IEthProviderHandlers];
+      if (handler) {
+        const mutableRequest = cloneDeep(request);
+        return handler(mutableRequest as JRPCRequest<unknown>) as Promise<void | Json>;
+      }
+    }
     return provider.request({ method: request.method, params: request.params });
   };
 }

--- a/packages/no-modal/src/providers/account-abstraction-provider/rpc/ethRpcMiddlewares.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/rpc/ethRpcMiddlewares.ts
@@ -1,11 +1,10 @@
-import { METHOD_TYPES } from "@toruslabs/ethereum-controllers";
+import { EIP_5792_METHODS, EIP_7702_METHODS, METHOD_TYPES } from "@toruslabs/ethereum-controllers";
 import {
-  cloneDeep,
   createScaffoldMiddlewareV2,
   type JRPCRequest,
-  Json,
   type MiddlewareConstraint,
   type MiddlewareParams,
+  providerErrors,
   rpcErrors,
 } from "@web3auth/auth";
 
@@ -218,29 +217,20 @@ export async function createEoaMiddleware({ aaProvider }: { aaProvider: IProvide
   });
 }
 
-/**
- * Creates a middleware that forwards the request to the given provider.
- *
- * If `overrideHandlers` is provided, the middleware will check if the request method is in the `overrideHandlers` object.
- * If it is, the middleware will call the handler function with the request and return the result.
- * If it is not, the middleware will forward the request to the given provider.
- *
- * @param provider - The provider to use.
- * @param overrideHandlers - The handlers to override.
- * @returns The middleware.
- */
-export function providerAsMiddleware(
-  provider: IProvider,
-  overrideHandlers?: Record<string, (request: JRPCRequest<unknown>) => Promise<unknown>>
-): MiddlewareConstraint {
-  return async ({ request }) => {
-    if (overrideHandlers) {
-      const handler = overrideHandlers[request.method as keyof IEthProviderHandlers];
-      if (handler) {
-        const mutableRequest = cloneDeep(request);
-        return handler(mutableRequest as JRPCRequest<unknown>) as Promise<void | Json>;
-      }
+export async function createEip7702And5792MiddlewareForAaProvider(): Promise<MiddlewareConstraint> {
+  const eip5792Methods = Object.values(EIP_5792_METHODS);
+  const eip7702Methods = Object.values(EIP_7702_METHODS);
+  const eip7702And5792Methods: string[] = [...eip5792Methods, ...eip7702Methods];
+  return async ({ request, next }) => {
+    if (eip7702And5792Methods.includes(request.method as string)) {
+      throw providerErrors.unsupportedMethod(`${request.method} is not supported for account abstraction provider`);
     }
+    return next(request);
+  };
+}
+
+export function providerAsMiddleware(provider: IProvider): MiddlewareConstraint {
+  return async ({ request }) => {
     return provider.request({ method: request.method, params: request.params });
   };
 }

--- a/packages/no-modal/src/react/wagmi/provider.ts
+++ b/packages/no-modal/src/react/wagmi/provider.ts
@@ -9,13 +9,13 @@ import {
   CreateConnectorFn,
   fallback,
   http,
+  injected,
   useConfig as useWagmiConfig,
   useConnectionEffect,
   useReconnect,
   WagmiProvider as WagmiProviderBase,
   webSocket,
 } from "wagmi";
-import { injected } from "wagmi/connectors";
 
 import { CHAIN_NAMESPACES, CustomChainConfig, IProvider, log, WalletInitializationError, WEB3AUTH_CONNECTOR_ID } from "../../base";
 import { useWeb3Auth, useWeb3AuthDisconnect } from "../hooks";

--- a/packages/no-modal/src/vue/wagmi/provider.ts
+++ b/packages/no-modal/src/vue/wagmi/provider.ts
@@ -1,4 +1,4 @@
-import { type Config, type Connection, type Connector, type CreateConnectorFn, hydrate } from "@wagmi/core";
+import { type Config, type Connection, type Connector, type CreateConnectorFn, hydrate, injected } from "@wagmi/core";
 import {
   configKey,
   createConfig as createWagmiConfig,
@@ -7,7 +7,6 @@ import {
   useConnectionEffect,
   useReconnect,
 } from "@wagmi/vue";
-import { injected } from "@wagmi/vue/connectors";
 import { randomId } from "@web3auth/auth";
 import { type Chain, defineChain, fallback, http, isAddress as isEvmAddress, webSocket } from "viem";
 import { defineComponent, h, PropType, provide, ref, shallowRef, watch } from "vue";


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->
https://consensyssoftware.atlassian.net/browse/EMBED-371?atlOrigin=eyJpIjoiYTBiYTU3ODRjNWU5NDY0ZjlhYjNlM2Y2YWM3ZWEzM2EiLCJwIjoiaiJ9

## Description

<!-- Describe your changes in detail -->
- throw a proper error (`ProviderErrors.Unsupported`) for the Eip7702/5792 calls from 4337 AA accounts.
- update demo for x402 feature

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AA provider RPC behavior and wagmi connector wiring, which can affect dApps using smart accounts or Wagmi; demo-only changes are low risk.
> 
> **Overview**
> **ERC-4337 account-abstraction providers** now reject **EIP-7702 and EIP-5792** JSON-RPC methods via new middleware in the AA RPC stack, returning an explicit unsupported-method error instead of forwarding them to the EOA provider. **AA setup** also fails fast when chain config is missing for the active chain.
> 
> Small fixes: optional chaining when inferring Solana vs EVM for linked accounts in the auth connector, and **wagmi `injected` connector** imports moved to the main `wagmi` / `@wagmi/core` entrypoints (React and Vue).
> 
> The **Vue x402 demo** points at a new default protected URL, switches to Base Sepolia using configured EIP-155 chains, and improves chain-switch logging. Lockfile bumps `@web3auth/modal` / `no-modal` to **11.0.0-beta.2**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23bdef6b95f526b52146b59af608b0ffe705abeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->