### PR TITLE
fix: default value for authBuildEnv

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -1529,9 +1529,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1549,9 +1546,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1569,9 +1563,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1589,9 +1580,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1609,9 +1597,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1629,9 +1614,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2995,9 +2977,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3015,9 +2994,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3035,9 +3011,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3055,9 +3028,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4682,9 +4652,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4699,9 +4666,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4716,9 +4680,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4733,9 +4694,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4750,9 +4708,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4767,9 +4722,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4784,9 +4736,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4801,9 +4750,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4818,9 +4764,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4835,9 +4778,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -1,4 +1,4 @@
-import { AuthConnectionConfigItem, serializeError } from "@web3auth/auth";
+import { AuthConnectionConfigItem, BUILD_ENV, serializeError } from "@web3auth/auth";
 import {
   ANALYTICS_EVENTS,
   ANALYTICS_SDK_TYPE,
@@ -95,7 +95,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
 
   constructor(options: Web3AuthOptions, initialState?: Partial<IWeb3AuthState>) {
     super(options, initialState);
-    this.options = { ...options };
+    this.options = { ...options, authBuildEnv: options.authBuildEnv || BUILD_ENV.PRODUCTION };
     if (!this.options.initialAuthenticationMode) {
       this.options.initialAuthenticationMode = CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN;
     }

--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -1,4 +1,4 @@
-import { ChainNamespaceType, type ProviderConfig } from "@toruslabs/base-controllers";
+import { ChainNamespaceType, getCaipChainId, type ProviderConfig } from "@toruslabs/base-controllers";
 import { CITADEL_SERVER_MAP } from "@toruslabs/constants";
 import { get, put } from "@toruslabs/http-helpers";
 import { SecurePubSub } from "@toruslabs/secure-pub-sub";
@@ -23,7 +23,6 @@ import {
 } from "@web3auth/auth";
 import { type default as WsEmbed, WS_EMBED_LOGIN_MODE } from "@web3auth/ws-embed";
 import deepmerge from "deepmerge";
-import { numberToHex } from "viem";
 
 import {
   AccountLinkingError,
@@ -408,13 +407,10 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
 
     const newChainConfig = this.coreOptions.chains.find((c) => c.chainId === newChainId);
     if (!newChainConfig) throw WalletInitializationError.invalidParams("Chain config is not available");
-
     if (newChainConfig.chainNamespace === CHAIN_NAMESPACES.SOLANA || newChainConfig.chainNamespace === CHAIN_NAMESPACES.EIP155) {
       if (!this.wsEmbedInstance?.provider) throw WalletInitializationError.notReady("Wallet embed is not ready");
-      const chainIdNum = parseInt(newChainConfig.chainId, 16);
-      // WsEmbed expects the chainId in hex format
-      const chainIdHex = numberToHex(chainIdNum);
-      await this.wsEmbedInstance.provider.request({ method: "wallet_switchChain", params: { chainId: chainIdHex } });
+      const caipChainId = getCaipChainId(newChainConfig);
+      await this.wsEmbedInstance.provider.request({ method: "wallet_switchChain", params: { chainId: caipChainId } });
     } else {
       await this.privateKeyProvider?.switchChain(params);
     }

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -6,6 +6,7 @@ import {
   SMART_ACCOUNT_EIP_STANDARD,
 } from "@toruslabs/ethereum-controllers";
 import {
+  BUILD_ENV,
   cloneDeep,
   CookieStorage,
   type IStorageAdapter,
@@ -147,7 +148,10 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     else log.setLevel("error");
     if (!options.initialAuthenticationMode) options.initialAuthenticationMode = CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN;
 
-    this.coreOptions = options;
+    this.coreOptions = {
+      ...options,
+      authBuildEnv: options.authBuildEnv || BUILD_ENV.PRODUCTION,
+    };
     this.storage = this.getStorageMethod();
     this.analytics = new Analytics();
     if (options.disableAnalytics) {


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small constructor default for an internal auth environment flag; no auth logic or API surface changes beyond ensuring production URLs when unset.
> 
> **Overview**
> The no-modal SDK constructor now **normalizes** `coreOptions` so **`authBuildEnv` defaults to `BUILD_ENV.PRODUCTION`** when callers omit it, matching the documented default on `IWeb3AuthCoreOptions`.
> 
> That value is already passed through **`fetchProjectConfig`**, Citadel/auth URLs, and initialization analytics, so unset options no longer leave `authBuildEnv` undefined for those code paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15e39fe52f27d479c286318cf99088d6b967366f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->