### PR TITLE
Update error message for other errors during account linking

### DIFF
--- a/packages/no-modal/src/account-linking/errors.ts
+++ b/packages/no-modal/src/account-linking/errors.ts
@@ -87,8 +87,12 @@ export function formatAccountLinkingErrorMessage(error: unknown, fallbackMessage
     return error.toString();
   }
 
+  if (error instanceof Web3AuthError) {
+    return `[${error.code}] Account linking error: ${error.message || fallbackMessage}`;
+  }
+
   if (error instanceof Error) {
-    return error.message || fallbackMessage;
+    return `Account linking error: ${error.message || fallbackMessage}`;
   }
 
   try {

--- a/packages/no-modal/test/accountLinkingErrors.test.ts
+++ b/packages/no-modal/test/accountLinkingErrors.test.ts
@@ -60,7 +60,7 @@ describe("account-linking errors", () => {
   });
 
   it("formats regular errors using the error message", () => {
-    expect(formatAccountLinkingErrorMessage(new Error("Something failed"))).toBe("Something failed");
+    expect(formatAccountLinkingErrorMessage(new Error("Something failed"))).toBe("Account linking error: Something failed");
   });
 
   it("formats plain objects as json and uses the fallback for circular values", () => {


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description
Update error message for other errors during account linking
- show error codes for non AccountLinkingError type if available
- add `Account linking error` prepend

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)
### Before - when type of error is not `AccountLinkingError` we plainly show the error message
<img width="419" height="268" alt="Screenshot 2026-06-02 at 11 23 37 PM" src="https://github.com/user-attachments/assets/d14c4f16-fe8f-4aed-a5c1-86ee51bc945d" />
<img width="412" height="241" alt="Screenshot 2026-06-02 at 10 09 54 PM" src="https://github.com/user-attachments/assets/884d3021-1501-4b1c-a208-49422d110530" />

### After
**If error is Web3Auth error. we prepend it with `[CODE] Account linking error: {message}**
<img width="414" height="260" alt="Screenshot 2026-06-02 at 11 25 56 PM" src="https://github.com/user-attachments/assets/329e9af3-4386-40fa-bdd6-9feba8a47e51" />

**For other errors (no error code). we just prepend it `Account linking error:**
<img width="411" height="261" alt="Screenshot 2026-06-02 at 11 36 36 PM" src="https://github.com/user-attachments/assets/67d01ba9-0f8b-4882-aeb0-b6826ee656aa" />

### Note: we don't show UI for unlinking so we only have `Account linking error:` prepend
<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to error string formatting in account linking with no auth or API behavior changes; only user-visible error text differs for some error types.
> 
> **Overview**
> **`formatAccountLinkingErrorMessage`** now standardizes user-facing copy for non–`AccountLinkingError` failures during account linking.
> 
> Other **`Web3AuthError`** instances (not `AccountLinkingError`) are formatted as **`[code] Account linking error: {message}`**, so error codes still appear when the underlying failure is a Web3Auth error type. Plain **`Error`** values are prefixed with **`Account linking error:`** instead of showing only the raw message. **`AccountLinkingError`** and JSON/fallback paths are unchanged.
> 
> Tests were updated to expect the new generic **`Error`** string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657d6b898c3d036aa310be84d85cb134bd47d013. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->