### PR TITLE
Fix/injected evm connect

### DIFF
--- a/packages/no-modal/src/connectors/base-evm-connector/baseEvmConnector.ts
+++ b/packages/no-modal/src/connectors/base-evm-connector/baseEvmConnector.ts
@@ -1,6 +1,7 @@
 import { ChainNamespaceType, signChallenge } from "@toruslabs/base-controllers";
 import { bytesToHexPrefixedString, utf8ToBytes } from "@toruslabs/metadata-helpers";
 import { EVM_METHOD_TYPES } from "@web3auth/ws-embed";
+import { checksumAddress } from "viem";
 import { generateSiweNonce } from "viem/siwe";
 
 import {
@@ -49,9 +50,9 @@ export abstract class BaseEvmConnector<T> extends BaseConnector<T> {
     const { chainNamespace } = currentChainConfig;
     const authServer = authServerUrl || citadelServerUrl(this.coreOptions.authBuildEnv);
     const payload = {
-      domain: window.location.origin,
+      domain: window.location.host,
       uri: window.location.href,
-      address: accountsToUse[0],
+      address: checksumAddress(accountsToUse[0] as `0x${string}`),
       chainId: parseInt(chainId, 16),
       version: "1",
       nonce: generateSiweNonce(),

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -170,7 +170,10 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
       this.update({ chainId });
       this.setupChainSwitchMiddleware();
       this.emit("chainChanged", chainId);
-      eoaProvider.removeListener("chainChanged", chainChangedHandler);
+
+      if (eoaProvider?.removeListener && typeof eoaProvider.removeListener === "function") {
+        eoaProvider.removeListener("chainChanged", chainChangedHandler);
+      }
     };
 
     if (eoaProvider?.once && typeof eoaProvider.once === "function") {

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -165,11 +165,21 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
     const engine = JRPCEngineV2.create({ middleware: [aaMiddleware, eip7702And5792Middleware, eoaMiddleware] });
     const provider = providerFromEngineV2(engine);
     this.updateProviderEngineProxy(provider);
-    eoaProvider.once("chainChanged", (chainId) => {
+
+    const chainChangedHandler = (chainId: string) => {
       this.update({ chainId });
       this.setupChainSwitchMiddleware();
       this.emit("chainChanged", chainId);
-    });
+      eoaProvider.removeListener("chainChanged", chainChangedHandler);
+    };
+
+    if (eoaProvider?.once && typeof eoaProvider.once === "function") {
+      eoaProvider.once("chainChanged", chainChangedHandler);
+    } else {
+      // some providers like trust wallet does not have `once` method, so we use `on` instead
+      // and cleanup the listener after the event triggers once
+      eoaProvider.on("chainChanged", chainChangedHandler);
+    }
   }
 
   public async updateAccount(_params: { privateKey: string }): Promise<void> {


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

https://consensyssoftware.atlassian.net/browse/EMBED-380?atlOrigin=eyJpIjoiMDQ3MTNlNjAyMTNmNGFmZDgzY2IyNDBmM2EwYTQxOWEiLCJwIjoiaiJ9

## Description

<!-- Describe your changes in detail -->

This PR fixes:
- phantom SIWE for connect and sign mode
- trust wallet connect with AA enabled

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted auth-payload and event-listener compatibility fixes for specific wallets; no broad API or security-model changes.
> 
> **Overview**
> Fixes **injected EVM wallet** connect/sign flows for **Phantom (SIWE)** and **Trust Wallet with account abstraction**.
> 
> **`baseEvmConnector`:** SIWE challenge payload now uses `window.location.host` for `domain` (instead of `origin`) and **EIP-55 checksummed** addresses via `viem`'s `checksumAddress`, aligning the message with what wallets like Phantom expect during connect-and-sign.
> 
> **`AccountAbstractionProvider`:** `chainChanged` handling no longer assumes `eoaProvider.once` exists. It uses `once` when available, otherwise registers with `on` and removes the listener after the first fire—covering providers such as Trust Wallet that lack `once`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6de2256fa86913aa05c9f0d70b65a8124337aa5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->