### PR TITLE
feat: consent analytics

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -50,13 +50,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.0-beta.2",
+      "version": "11.0.1",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.10.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.1",
-        "@web3auth/no-modal": "^11.0.0-beta.2",
+        "@web3auth/no-modal": "^11.0.1",
         "@web3auth/ws-embed": "^6.0.4",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",
@@ -134,7 +134,7 @@
     },
     "../../packages/no-modal": {
       "name": "@web3auth/no-modal",
-      "version": "11.0.0-beta.2",
+      "version": "11.0.1",
       "license": "ISC",
       "dependencies": {
         "@metamask/connect-evm": "^1.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4475,9 +4475,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4492,9 +4489,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4507,9 +4501,6 @@
       "integrity": "sha512-tbaX1tZCSpGifDNBfDdEZAMxVF3Yg4bhFP/bm1needc0diqb+Zflc0u5tM5/6BWDMITQDwenJVsNiQ8ZdtJURA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -4525,9 +4516,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5015,9 +5003,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5033,9 +5018,6 @@
       "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5053,9 +5035,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5071,9 +5050,6 @@
       "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5091,9 +5067,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5109,9 +5082,6 @@
       "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5553,9 +5523,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5570,9 +5537,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5587,9 +5551,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5604,9 +5565,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5621,9 +5579,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5638,9 +5593,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5655,9 +5607,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5672,9 +5621,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5689,9 +5635,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5706,9 +5649,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5723,9 +5663,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5738,9 +5675,6 @@
       "integrity": "sha512-0uMOcf3eZ5K+K4cYHkdxShFMPlPXCOdfDFEFn9dNYAEEd2cVvmOfH7zFgRVoDgmtQ1m9k5q7qfrHzyMAubKYUA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5756,9 +5690,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12148,9 +12079,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12168,9 +12096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12188,9 +12113,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12208,9 +12130,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13537,9 +13456,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13554,9 +13470,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13571,9 +13484,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13588,9 +13498,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13605,9 +13512,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13622,9 +13526,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13639,9 +13540,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13656,9 +13554,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13673,9 +13568,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -13690,9 +13582,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24281,9 +24170,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24303,9 +24189,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -24327,9 +24210,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -24349,9 +24229,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -288,7 +288,19 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
   }
 
   public async acceptConsent(): Promise<void> {
-    await super.completeConsentAcceptance();
+    try {
+      await super.completeConsentAcceptance();
+      this.analytics.track(ANALYTICS_EVENTS.USER_CONSENT_ACCEPTED, {
+        connector: this.primaryConnectorName,
+      });
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.analytics.track(ANALYTICS_EVENTS.USER_CONSENT_ERRORED, {
+        connector: this.primaryConnectorName,
+        error: `Error while accepting consent: ${errorMessage}`,
+      });
+      throw error;
+    }
   }
 
   public async switchAccount(account: LinkedAccountInfo): Promise<void> {
@@ -928,9 +940,17 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
 
   private onDeclineConsent = async (): Promise<void> => {
     try {
+      this.analytics.track(ANALYTICS_EVENTS.USER_CONSENT_DECLINED, {
+        connector: this.primaryConnectorName,
+      });
       await this.logout();
     } catch (error) {
       log.error("Error while declining consent", error);
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      this.analytics.track(ANALYTICS_EVENTS.USER_CONSENT_ERRORED, {
+        connector: this.primaryConnectorName,
+        error: `Error while declining consent: ${errorMessage}`,
+      });
     } finally {
       this.loginModal.closeModal();
     }

--- a/packages/modal/src/ui/components/Footer/Footer.tsx
+++ b/packages/modal/src/ui/components/Footer/Footer.tsx
@@ -1,5 +1,8 @@
+import { ANALYTICS_EVENTS } from "@web3auth/no-modal";
+import { useContext } from "react";
 import { useTranslation } from "react-i18next";
 
+import { AnalyticsContext } from "../../context/AnalyticsContext";
 import i18n from "../../localeImport";
 import { FooterProps } from "./Footer.type";
 /**
@@ -8,6 +11,7 @@ import { FooterProps } from "./Footer.type";
  */
 function Footer({ privacyPolicy, termsOfService }: FooterProps) {
   const [t] = useTranslation(undefined, { i18n });
+  const { analytics } = useContext(AnalyticsContext);
 
   return (
     <div className="wta:mx-auto wta:mt-auto wta:flex wta:flex-col wta:items-center wta:justify-center wta:gap-y-4 wta:pt-5">
@@ -15,14 +19,22 @@ function Footer({ privacyPolicy, termsOfService }: FooterProps) {
         <p className="wta:mx-auto wta:w-4/5 wta:text-center wta:text-xs wta:text-app-gray-500 wta:dark:text-app-gray-400">
           {t("modal.footer.by-signing-in")}{" "}
           {termsOfService && (
-            <a href={termsOfService} className="wta:text-app-primary-600 wta:dark:text-app-primary-500">
+            <a
+              href={termsOfService}
+              onClick={() => analytics?.track(ANALYTICS_EVENTS.TERMS_OF_SERVICE_CLICKED)}
+              className="wta:text-app-primary-600 wta:dark:text-app-primary-500"
+            >
               {t("modal.footer.terms-of-service")}{" "}
             </a>
           )}
           {privacyPolicy && (
             <>
               {t("modal.footer.and")}{" "}
-              <a href={privacyPolicy} className="wta:text-app-primary-600 wta:dark:text-app-primary-500">
+              <a
+                href={privacyPolicy}
+                onClick={() => analytics?.track(ANALYTICS_EVENTS.PRIVACY_POLICY_CLICKED)}
+                className="wta:text-app-primary-600 wta:dark:text-app-primary-500"
+              >
                 {t("modal.footer.privacy-policy")}
               </a>
             </>

--- a/packages/modal/src/ui/components/Loader/Loader.tsx
+++ b/packages/modal/src/ui/components/Loader/Loader.tsx
@@ -1,7 +1,8 @@
-import { WALLET_CONNECTOR_TYPE } from "@web3auth/no-modal";
-import { useEffect, useMemo, useState } from "react";
+import { ANALYTICS_EVENTS, WALLET_CONNECTOR_TYPE } from "@web3auth/no-modal";
+import { useContext, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 
+import { AnalyticsContext } from "../../context/AnalyticsContext";
 import { MODAL_STATUS } from "../../interfaces";
 import i18n from "../../localeImport";
 import Image from "../Image";
@@ -121,6 +122,7 @@ function ConsentRequiredStatus(props: {
   const { onAccept, onDecline, privacyPolicy, tncLink } = props;
   const [t] = useTranslation(undefined, { i18n });
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const { analytics } = useContext(AnalyticsContext);
 
   const handleAccept = async () => {
     setIsSubmitting(true);
@@ -161,6 +163,7 @@ function ConsentRequiredStatus(props: {
           {tncLink && (
             <a
               href={tncLink}
+              onClick={() => analytics?.track(ANALYTICS_EVENTS.TERMS_OF_SERVICE_CLICKED)}
               target="_blank"
               rel="noopener noreferrer"
               className="w3a--btn wta:text-sm! wta:font-light wta:justify-start! wta:rounded-full wta:border-app-gray-50 wta:bg-app-gray-50 wta:p-3 wta:text-left wta:text-app-gray-700 wta:hover:border-app-gray-200 wta:hover:bg-app-gray-200 wta:hover:text-app-gray-900 wta:dark:border-app-gray-800 wta:dark:bg-app-gray-800 wta:dark:text-app-white wta:dark:hover:border-app-gray-600 wta:dark:hover:bg-app-gray-600"
@@ -171,6 +174,7 @@ function ConsentRequiredStatus(props: {
           {privacyPolicy && (
             <a
               href={privacyPolicy}
+              onClick={() => analytics?.track(ANALYTICS_EVENTS.PRIVACY_POLICY_CLICKED)}
               target="_blank"
               rel="noopener noreferrer"
               className="w3a--btn wta:text-sm! wta:font-light wta:justify-start! wta:rounded-full wta:border-app-gray-50 wta:bg-app-gray-50 wta:p-3 wta:text-left wta:text-app-gray-700 wta:hover:border-app-gray-200 wta:hover:bg-app-gray-200 wta:hover:text-app-gray-900 wta:dark:border-app-gray-800 wta:dark:bg-app-gray-800 wta:dark:text-app-white wta:dark:hover:border-app-gray-600 wta:dark:hover:bg-app-gray-600"

--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -18,6 +18,7 @@ import {
   type MetaMaskConnectorData,
   type SDK_CONNECTED_EVENT_DATA,
   SDK_CONSENT_ACCEPTED_EVENT_DATA,
+  SDK_CONSENT_REQUIRING_EVENT_DATA,
   type WALLET_CONNECTOR_TYPE,
   WALLET_CONNECTORS,
   type WalletConnectV2Data,
@@ -605,8 +606,12 @@ export class LoginModal {
       if (this.modalStatus === MODAL_STATUS.CONSENT_REQUIRING) return;
       this.setState({ status: MODAL_STATUS.AUTHORIZED, postLoadingMessage: "" });
     });
-    listener.on(CONNECTOR_EVENTS.CONSENT_REQUIRING, () => {
+    listener.on(CONNECTOR_EVENTS.CONSENT_REQUIRING, (data: SDK_CONSENT_REQUIRING_EVENT_DATA) => {
       this.setState({ status: MODAL_STATUS.CONSENT_REQUIRING, modalVisibility: true });
+
+      this.analytics?.track(ANALYTICS_EVENTS.USER_CONSENT_STARTED, {
+        connector: data.connectorName,
+      });
     });
     listener.on(CONNECTOR_EVENTS.CONSENT_ACCEPTED, (data: SDK_CONSENT_ACCEPTED_EVENT_DATA) => {
       if (this.uiConfig.initialAuthenticationMode === CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN) {

--- a/packages/modal/src/ui/loginModal.tsx
+++ b/packages/modal/src/ui/loginModal.tsx
@@ -607,8 +607,8 @@ export class LoginModal {
       this.setState({ status: MODAL_STATUS.AUTHORIZED, postLoadingMessage: "" });
     });
     listener.on(CONNECTOR_EVENTS.CONSENT_REQUIRING, (data: SDK_CONSENT_REQUIRING_EVENT_DATA) => {
+      if (this.modalStatus === MODAL_STATUS.CONSENT_REQUIRING) return;
       this.setState({ status: MODAL_STATUS.CONSENT_REQUIRING, modalVisibility: true });
-
       this.analytics?.track(ANALYTICS_EVENTS.USER_CONSENT_STARTED, {
         connector: data.connectorName,
       });

--- a/packages/modal/test/modalManager.test.ts
+++ b/packages/modal/test/modalManager.test.ts
@@ -23,12 +23,12 @@ vi.mock("@web3auth/no-modal", async () => {
 import {
   CHAIN_NAMESPACES,
   CONNECTED_STATUSES,
-  type ConnectedAccountInfo,
   Connection,
   CONNECTOR_EVENTS,
   CONNECTOR_INITIAL_AUTHENTICATION_MODE,
   type IConnector,
   type LinkAccountResult,
+  type LinkedAccountInfo,
   type ProjectConfig,
   WALLET_CONNECTORS,
   WalletInitializationError,
@@ -49,11 +49,11 @@ class TestWeb3Auth extends Web3Auth {
     return this.getInitializationTrackData();
   }
 
-  public exposeSetConnectedWalletConnector(connector: IConnector<unknown>, account?: ConnectedAccountInfo | null) {
+  public exposeSetConnectedWalletConnector(connector: IConnector<unknown>, account?: LinkedAccountInfo | null) {
     this.setConnectedWalletConnector(connector, account);
   }
 
-  public exposeSetActiveWalletConnectorKey(account?: ConnectedAccountInfo | null) {
+  public exposeSetActiveWalletConnectorKey(account?: LinkedAccountInfo | null) {
     this.setActiveWalletConnectorKey(account);
   }
 }
@@ -85,7 +85,7 @@ function createSdk(overrides: Partial<Web3AuthOptions> = {}) {
   } as never);
 }
 
-function createConnectedWalletAccount(overrides: Partial<ConnectedAccountInfo> = {}): ConnectedAccountInfo {
+function createConnectedWalletAccount(overrides: Partial<LinkedAccountInfo> = {}): LinkedAccountInfo {
   return {
     id: "wallet-1",
     accountType: "external_wallet",
@@ -275,7 +275,7 @@ describe("Web3Auth (modal)", () => {
 
     vi.spyOn(sdk as unknown as { getMainAuthConnector: () => unknown }, "getMainAuthConnector").mockReturnValue(authConnector as never);
     vi.spyOn(
-      sdk as unknown as { getConnectedWalletConnector: (account?: ConnectedAccountInfo | null) => unknown },
+      sdk as unknown as { getConnectedWalletConnector: (account?: LinkedAccountInfo | null) => unknown },
       "getConnectedWalletConnector"
     ).mockReturnValue(existingConnector as never);
 
@@ -361,7 +361,7 @@ describe("Web3Auth (modal)", () => {
 
     vi.spyOn(sdk as unknown as { getMainAuthConnector: () => unknown }, "getMainAuthConnector").mockReturnValue(authConnector as never);
     vi.spyOn(
-      sdk as unknown as { getConnectedWalletConnector: (account?: ConnectedAccountInfo | null) => unknown },
+      sdk as unknown as { getConnectedWalletConnector: (account?: LinkedAccountInfo | null) => unknown },
       "getConnectedWalletConnector"
     ).mockReturnValue(null);
 

--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -127,6 +127,8 @@ export const ANALYTICS_EVENTS = {
   USER_CONSENT_ACCEPTED: "User Consent Accepted",
   USER_CONSENT_DECLINED: "User Consent Declined",
   USER_CONSENT_ERRORED: "User Consent Errored",
+  TERMS_OF_SERVICE_CLICKED: "Terms of Service Clicked",
+  PRIVACY_POLICY_CLICKED: "Privacy Policy Clicked",
   // Login Modal
   LOGIN_MODAL_OPENED: "Login Modal Opened",
   LOGIN_MODAL_CLOSED: "Login Modal Closed",

--- a/packages/no-modal/src/base/analytics.ts
+++ b/packages/no-modal/src/base/analytics.ts
@@ -122,6 +122,11 @@ export const ANALYTICS_EVENTS = {
   MFA_ENABLEMENT_FAILED: "MFA Enablement Failed",
   MFA_MANAGEMENT_SELECTED: "MFA Management Selected",
   MFA_MANAGEMENT_FAILED: "MFA Management Failed",
+  // Consent Flow
+  USER_CONSENT_STARTED: "User Consent Started",
+  USER_CONSENT_ACCEPTED: "User Consent Accepted",
+  USER_CONSENT_DECLINED: "User Consent Declined",
+  USER_CONSENT_ERRORED: "User Consent Errored",
   // Login Modal
   LOGIN_MODAL_OPENED: "Login Modal Opened",
   LOGIN_MODAL_CLOSED: "Login Modal Closed",

--- a/packages/no-modal/src/base/core/IWeb3Auth.ts
+++ b/packages/no-modal/src/base/core/IWeb3Auth.ts
@@ -278,12 +278,13 @@ export interface IWeb3Auth extends IWeb3AuthCore {
 }
 
 export type SDK_CONNECTED_EVENT_DATA = CONNECTED_EVENT_DATA & { loginMode: LoginModeType; pendingUserConsent?: boolean };
-export type SDK_CONSENT_ACCEPTED_EVENT_DATA = { reconnected: boolean };
+export type SDK_CONSENT_ACCEPTED_EVENT_DATA = Partial<CONNECTED_EVENT_DATA> & { reconnected: boolean };
+export type SDK_CONSENT_REQUIRING_EVENT_DATA = Partial<CONNECTED_EVENT_DATA>;
 
 export type Web3AuthNoModalEvents = Omit<ConnectorEvents, "connected" | "errored" | "ready" | "consent_requiring" | "consent_accepted"> & {
   [CONNECTOR_EVENTS.READY]: () => void;
   [CONNECTOR_EVENTS.CONNECTED]: (data: SDK_CONNECTED_EVENT_DATA) => void;
-  [CONNECTOR_EVENTS.CONSENT_REQUIRING]: () => void;
+  [CONNECTOR_EVENTS.CONSENT_REQUIRING]: (data: SDK_CONSENT_REQUIRING_EVENT_DATA) => void;
   [CONNECTOR_EVENTS.CONSENT_ACCEPTED]: (data: SDK_CONSENT_ACCEPTED_EVENT_DATA) => void;
   [CONNECTOR_EVENTS.ERRORED]: (error: Web3AuthError, loginMode: LoginModeType) => void;
   [CONNECTOR_EVENTS.CONNECTION_UPDATED]: (data: CONNECTION_UPDATED_EVENT_DATA) => void;

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1156,7 +1156,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       const pendingUserConsent = this.consentRequired && !this.state.hasUserConsent;
       if (pendingUserConsent && !isConnectAndSign) {
         this.status = CONNECTOR_STATUS.CONSENT_REQUIRING;
-        this.emit(CONNECTOR_EVENTS.CONSENT_REQUIRING);
+        this.emit(CONNECTOR_EVENTS.CONSENT_REQUIRING, { ...data });
         log.debug("consent_requiring", this.status, this.primaryConnectorName);
       } else {
         // In CONNECT_AND_SIGN mode the AUTHORIZED handler can run before this point (e.g. when `ssr=true`
@@ -1315,7 +1315,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       // if the user has not consented yet, we will ask for consent
       if (this.consentRequired && this.connection && !this.state.hasUserConsent) {
         this.status = CONNECTOR_STATUS.CONSENT_REQUIRING;
-        this.emit(CONNECTOR_EVENTS.CONSENT_REQUIRING);
+        this.emit(CONNECTOR_EVENTS.CONSENT_REQUIRING, { connectorName: data.connector });
         log.debug("consent_requiring", this.status, this.primaryConnectorName);
       } else {
         this.status = CONNECTOR_STATUS.AUTHORIZED;


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->
https://consensyssoftware.atlassian.net/browse/EMBED-53?atlOrigin=eyJpIjoiZjE1ODBiMDE4YmJjNGI5YTkzNjZmMTQ5N2RiYTA4MTEiLCJwIjoiaiJ9

## Description

<!-- Describe your changes in detail -->

Add analytics related to the consent flow.

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Analytics

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are observability-only (analytics + event payload typing) with no auth or consent logic changes beyond passing connector metadata; lockfile updates are routine version bumps.
> 
> **Overview**
> Adds **Segment analytics** for the user consent flow and related legal-link clicks across modal and no-modal.
> 
> New `ANALYTICS_EVENTS` cover consent **started**, **accepted**, **declined**, and **errored**, plus **Terms of Service** and **Privacy Policy** link clicks. The modal SDK tracks accept/decline (with connector context and error messages on failure) in `modalManager`, fires **User Consent Started** when the consent UI appears in `loginModal`, and records ToS/privacy clicks from the **Footer** and consent **Loader** via `AnalyticsContext`.
> 
> `CONSENT_REQUIRING` now carries partial connected-event data (`connectorName`) from `noModal` so analytics can attribute the connector; consent event TypeScript types were updated accordingly. Tests were adjusted to use `LinkedAccountInfo` instead of `ConnectedAccountInfo`. Lockfiles bump workspace packages from `11.0.0-beta.2` to `11.0.1` and include incidental optional-native dependency metadata churn.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78265806a832b775bef6f42ca25ab8ed05b0d4e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->