### PR TITLE
fix: skip cleanup for connectors which is not initialized

### DIFF
--- a/demo/wagmi-react-app/package-lock.json
+++ b/demo/wagmi-react-app/package-lock.json
@@ -32,13 +32,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.1",
+      "version": "11.0.2",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.10.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.1",
-        "@web3auth/no-modal": "^11.0.1",
+        "@web3auth/no-modal": "^11.0.2",
         "@web3auth/ws-embed": "^6.0.4",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29514,7 +29514,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29524,7 +29523,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -31201,8 +31199,7 @@
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/schema-utils": {
       "version": "3.3.0",

--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -417,12 +417,9 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
   }
 
   public async cleanup(): Promise<void> {
-    if (!this.authInstance) throw WalletInitializationError.notReady("authInstance is not ready");
-    await this.authInstance.cleanup();
+    await this.authInstance?.cleanup();
+    this.wsEmbedInstance?.clearInit();
 
-    if (this.wsEmbedInstance) {
-      this.wsEmbedInstance.clearInit();
-    }
     this._solanaWallet = null;
     this.unbindWsEmbedProviderEvents();
   }

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -371,7 +371,10 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
 
   public async cleanup(): Promise<void> {
     for (const connector of this.connectors) {
-      if (connector.cleanup) await connector.cleanup();
+      // if the connector is not ready, we don't need to cleanup
+      // this means that we load the connector (coz of the dashboard config) but the clients did not use it (i.e. with `showOnModal` set to false)
+      // example use case: external wallet **ONLY** login mode but the ClientID has enabled Auth connection in dashboard.
+      if (connector.cleanup && connector.status !== CONNECTOR_STATUS.NOT_READY) await connector.cleanup();
     }
   }
 


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

This PR fixes cleanup logic in the `noModal`, to do the cleanup **ONLY** for the initialized connectors.
In some cases, not all the user registered connectors might not be initialized (depending on the project use-cases), so for this, we only need to do the `cleanup` for the initialized connectors, avoiding unnecessary issues.

Example use-case:
External Wallet only connect using the ClientId which has Social login configured in dashboard.
In this case, `AuthConnector` is still loaded but never initialized. When invalidating the web3auth state in providers, doing cleanup for `AuthConnector` will run into an error.

## Screenshots (if appropriate)

<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted lifecycle bugfix with optional chaining; no auth or connection flow changes for initialized connectors.
> 
> **Overview**
> Fixes teardown when dashboard-loaded connectors were never initialized (e.g. external-wallet-only apps with Auth enabled in the dashboard).
> 
> **`Web3AuthNoModal.cleanup`** now skips connectors whose `status` is `NOT_READY`, so only initialized connectors run `cleanup` during provider invalidation.
> 
> **`AuthConnector.cleanup`** no longer throws if `authInstance` was never created; it uses optional chaining for `authInstance?.cleanup()` and `wsEmbedInstance?.clearInit()`.
> 
> Lockfiles bump **`@web3auth/modal`** / **`@web3auth/no-modal`** to **11.0.2** in the demo and root lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4e719eea71a1cfba9304a1b51403c9c52d3b3d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->