### PR TITLE
added postcss cascade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1863,6 +1863,56 @@
         "node": ">=6"
       }
     },
+    "node_modules/@csstools/postcss-cascade-layers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-cascade-layers/-/postcss-cascade-layers-6.0.0.tgz",
+      "integrity": "sha512-WhsECqmrEZQGqaPlBA7JkmF/CJ2/+wetL4fkL9sOPccKd32PQ1qToFM6gqSI5rkpmYqubvbxjEJhyMTHYK0vZQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "dependencies": {
+        "@csstools/selector-specificity": "^6.0.0",
+        "postcss-selector-parser": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4"
+      }
+    },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-6.0.0.tgz",
+      "integrity": "sha512-4sSgl78OtOXEX/2d++8A83zHNTgwCJMaR24FvsYL7Uf/VS8HZk9PTwR51elTbGqMuwH3szLvvOXEaVnqn0Z3zA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "postcss-selector-parser": "^7.1.1"
+      }
+    },
     "node_modules/@ecies/ciphers": {
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/@ecies/ciphers/-/ciphers-0.2.6.tgz",
@@ -29514,6 +29564,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -29523,6 +29574,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -35689,6 +35741,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.29.7",
         "@coinbase/wallet-sdk": "^4.3.7",
+        "@csstools/postcss-cascade-layers": "^6.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-url": "^8.0.2",
@@ -35746,6 +35799,29 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "packages/modal/node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "packages/modal/node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
       }
     },
     "packages/no-modal": {
@@ -35932,6 +36008,16 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
+      }
+    },
+    "packages/no-modal/node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "packages/no-modal/node_modules/semver": {

--- a/packages/modal/package.json
+++ b/packages/modal/package.json
@@ -55,6 +55,7 @@
   "devDependencies": {
     "@babel/preset-react": "^7.29.7",
     "@coinbase/wallet-sdk": "^4.3.7",
+    "@csstools/postcss-cascade-layers": "^6.0.0",
     "@rollup/plugin-json": "^6.1.0",
     "@rollup/plugin-replace": "^6.0.3",
     "@rollup/plugin-url": "^8.0.2",

--- a/packages/modal/postcss.config.js
+++ b/packages/modal/postcss.config.js
@@ -3,6 +3,13 @@ const prefix = ".w3a-parent-container";
 module.exports = {
   plugins: {
     "@tailwindcss/postcss": {},
+    // Flatten Tailwind v4's @layer output into unlayered, specificity-ordered
+    // rules. Layered CSS always loses to a host dApp's unlayered global resets
+    // (preflight, `* { margin: 0 }`, vendor preflight), which would break the
+    // modal UI. Since every selector is scoped under `.w3a-parent-container`,
+    // emitting unlayered rules lets the modal win on normal specificity without
+    // requiring any CSS changes in consuming apps.
+    "@csstools/postcss-cascade-layers": {},
     "postcss-prefix-selector": {
       prefix,
       transform(_, selector, prefixedSelector) {


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

Fixes modal styles being overridden by host dApp global CSS by flattening
Tailwind v4's cascade layers into unlayered, specificity-ordered rules.

`@web3auth/modal` is built with Tailwind v4, which emits all styles inside CSS
cascade layers (`@layer base`, `@layer utilities`, ...). Per the CSS cascade
spec, **unlayered styles always win over layered styles regardless of
specificity**.

When the modal's CSS is injected into a consuming app, that app's *unlayered*
global resets (Tailwind preflight, `* { margin: 0 }`, vendor resets, etc.)
override the modal's *layered* rules. The result is broken styling on the
contents of the modal in host apps (reproduced in `w3a-new-demo`).

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

### Before
<img width="1913" height="862" alt="Screenshot 2026-06-09 at 5 21 48 PM" src="https://github.com/user-attachments/assets/ae4ee314-2ca5-4187-8fba-7b2df9f117fa" />


### After
<img width="1915" height="857" alt="Screenshot 2026-06-09 at 5 19 28 PM" src="https://github.com/user-attachments/assets/ab57face-49b9-4c6b-8b6d-ba505630db8b" />


<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time CSS processing change only in the modal package; no runtime auth or API logic, with intended effect of fixing styling regressions in consuming apps.
> 
> **Overview**
> Fixes **modal UI styling being crushed by host dApp global CSS** when `@web3auth/modal` is embedded. Tailwind v4 emits rules inside cascade layers; unlayered host resets (preflight, `* { margin: 0 }`, etc.) always beat layered rules, so modal styles lost regardless of selector specificity.
> 
> The modal **PostCSS pipeline** now runs **`@csstools/postcss-cascade-layers`** after `@tailwindcss/postcss` and before `postcss-prefix-selector`, flattening layered output into unlayered, specificity-ordered CSS still scoped under `.w3a-parent-container`. **`@csstools/postcss-cascade-layers`** is added as a devDependency on `packages/modal` with lockfile updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8218d66e4805c9cf1ce76606ee2b5b4f9be7c2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->