### PR TITLE
fix: metamask switch sol

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -21,7 +21,7 @@
         "@web3auth/modal": "file:../../packages/modal",
         "@web3auth/no-modal": "file:../../packages/no-modal",
         "@web3auth/sign-in-with-web3": "^6.1.0",
-        "@web3auth/ws-embed": "^6.0.4",
+        "@web3auth/ws-embed": "^6.1.0",
         "ox": "^0.14.27",
         "petite-vue-i18n": "^11.4.4",
         "react": "^19.2.7",
@@ -50,14 +50,14 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.0.2",
+      "version": "11.1.1",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.10.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.1",
-        "@web3auth/no-modal": "^11.0.2",
-        "@web3auth/ws-embed": "^6.0.4",
+        "@web3auth/no-modal": "^11.1.0",
+        "@web3auth/ws-embed": "^6.1.0",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",
         "clsx": "^2.1.1",
@@ -73,6 +73,7 @@
       "devDependencies": {
         "@babel/preset-react": "^7.29.7",
         "@coinbase/wallet-sdk": "^4.3.7",
+        "@csstools/postcss-cascade-layers": "^6.0.0",
         "@rollup/plugin-json": "^6.1.0",
         "@rollup/plugin-replace": "^6.0.3",
         "@rollup/plugin-url": "^8.0.2",
@@ -134,7 +135,7 @@
     },
     "../../packages/no-modal": {
       "name": "@web3auth/no-modal",
-      "version": "11.0.2",
+      "version": "11.1.0",
       "license": "ISC",
       "dependencies": {
         "@metamask/connect-evm": "^2.0.0",
@@ -160,7 +161,7 @@
         "@walletconnect/types": "^2.23.9",
         "@walletconnect/utils": "^2.23.9",
         "@web3auth/auth": "^11.8.1",
-        "@web3auth/ws-embed": "^6.0.4",
+        "@web3auth/ws-embed": "^6.1.0",
         "bignumber.js": "~9.3.1",
         "deepmerge": "^4.3.1",
         "ethers": "^6.16.0",
@@ -3329,9 +3330,9 @@
       }
     },
     "node_modules/@toruslabs/ethereum-controllers": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/ethereum-controllers/-/ethereum-controllers-9.10.0.tgz",
-      "integrity": "sha512-GahJZFEp1bOe/zlAjTLmmDR+/ibqqGf1yH+B///XbXfO7EFXM13Z3n/OCldVpTAW4ItQkP4l4VivmZhRDbfBKQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/ethereum-controllers/-/ethereum-controllers-9.11.0.tgz",
+      "integrity": "sha512-Dd441FQB4hc4PIpXp0Tj1NvKrw8MGDEoy+No6o5Z4q2OxVvdD+70nh2HRlUAVRx6001FYrDjX/jyzUCFihES7g==",
       "license": "ISC",
       "dependencies": {
         "@metamask/smart-accounts-kit": "~1.4.0",
@@ -3572,9 +3573,9 @@
       }
     },
     "node_modules/@toruslabs/solana-controllers": {
-      "version": "9.10.0",
-      "resolved": "https://registry.npmjs.org/@toruslabs/solana-controllers/-/solana-controllers-9.10.0.tgz",
-      "integrity": "sha512-fb7RDnUVrvSFd7LVmhKTsE3HNKHQJB9ucqzG6h7uPAepOqOlSNAuTZO0jepVpv5W1u8e7oiVwkuQmfEXfOmOoQ==",
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/@toruslabs/solana-controllers/-/solana-controllers-9.11.0.tgz",
+      "integrity": "sha512-RUnPektZlEAFN8UnWiV0P3bjoqwJjTTPN6Qi3zoAgviT712K4nzLFknwe/gtdcVYhguy9d36g8XeqoQJR4iXEA==",
       "license": "ISC",
       "dependencies": {
         "@solana-program/compute-budget": "^0.15.0",
@@ -5331,13 +5332,13 @@
       }
     },
     "node_modules/@web3auth/ws-embed": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@web3auth/ws-embed/-/ws-embed-6.0.4.tgz",
-      "integrity": "sha512-7NRE8GPryWkdN8Hsh8Ht/nldCtqzaqLyjvypYiAiOlb6GdENCiI9EzA1650Ujzt9o078tL/OsI6OWeLEqwnojA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@web3auth/ws-embed/-/ws-embed-6.1.0.tgz",
+      "integrity": "sha512-EsF2u6Ijhp/VVXYVQyGEWI/bcXDQG5BmCEuCQb7xNYuhd6ovEbG5bxi1/nU9NieK750Z8zrpYeeKXKnzYmbyQw==",
       "license": "ISC",
       "dependencies": {
         "@scure/base": "2.2.0",
-        "@toruslabs/base-controllers": "^9.9.1",
+        "@toruslabs/base-controllers": "^9.10.0",
         "@toruslabs/constants": "^16.1.1",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.1",

--- a/demo/vue-app-new/src/components/AppDashboard.vue
+++ b/demo/vue-app-new/src/components/AppDashboard.vue
@@ -380,7 +380,7 @@ const canSwitchEvmChain = computed(() => {
 });
 
 const canSwitchChainNamespace = computed(() => {
-  if (!isConnected.value || connection.value?.connectorName !== WALLET_CONNECTORS.AUTH) return false;
+  if (!isConnected.value) return false;
   if (chainNamespace.value === CHAIN_NAMESPACES.EIP155) return solanaChains.value.length > 0;
   if (chainNamespace.value === CHAIN_NAMESPACES.SOLANA) return eip155Chains.value.length > 0;
   return false;

--- a/demo/vue-app-new/src/components/AppSettings.vue
+++ b/demo/vue-app-new/src/components/AppSettings.vue
@@ -114,6 +114,17 @@ const onChainChange = (chainIds: string[]) => {
   formData.smartAccountChains = formData.smartAccountChains.filter((chain) => chainIds.includes(chain));
 };
 
+const onDefaultChainChange = (chainId?: string) => {
+  log.info("onDefaultChainChange", chainId);
+  formData.defaultChainId = chainId;
+
+  if (!chainId || !formData.chains.includes(chainId)) return;
+
+  // Keep the selected default chain distinct from the first configured chain
+  // so external-wallet init can still exercise defaultChainId vs first-chain behavior.
+  formData.chains = [...formData.chains.filter((configuredChainId) => configuredChainId !== chainId), chainId];
+};
+
 const onSmartAccountChainChange = (chainIds: string[]) => {
   log.info("onSmartAccountChainChange", chainIds);
   formData.smartAccountChainsConfig = {};
@@ -223,6 +234,7 @@ const onSmartAccountChainChange = (chainIds: string[]) => {
             :placeholder="$t('app.defaultChainId')"
             matchParentsWidth
             :options="defaultChainOptions"
+            @update:model-value="onDefaultChainChange"
           />
           <Select
             v-model="formData.connectors"

--- a/docs/qa-checklist-modal.md
+++ b/docs/qa-checklist-modal.md
@@ -1,0 +1,290 @@
+# `@web3auth/modal` QA Checklist
+
+This checklist is for manual QA and focused regression testing of the modal SDK.
+
+Use it to validate:
+- login and connect entry points
+- session rehydration
+- disconnect and cleanup behavior
+- multichain switching
+- Auth-only actions such as MFA and account linking flows surfaced through modal UX
+
+## Recommended Test Matrix
+
+Run the relevant sections against:
+- desktop browser with popup flow enabled
+- mobile browser / mobile wallet handoff where applicable
+- EVM-only app config
+- Solana-only app config
+- mixed EVM + Solana app config
+- `connect-and-sign` and `connect-only` authentication modes
+- light mode, dark mode, and embedded widget if those are supported by the test app
+
+## 1. Modal Initialization
+
+### Core initialization
+- [ ] `init()` completes and the SDK reaches `READY`.
+- [ ] The modal renders in the expected mode: overlay or embedded widget.
+- [ ] Project-configured auth login methods appear in the expected order.
+- [ ] External wallet section is visible only when external wallets are enabled.
+- [ ] Hidden connectors and hidden login methods do not appear.
+
+### Config and availability edge cases
+- [ ] Invalid auth connection config fails fast with a clear initialization error.
+- [ ] Missing connector config for a connector shown on modal fails fast.
+- [ ] `hideWalletDiscovery` hides discovery-based wallets and WalletConnect v2.
+- [ ] Dashboard-disabled wallets are not shown.
+- [ ] MetaMask is still shown even if included in disabled wallet settings.
+- [ ] External-wallet-only mode skips the in-app login screen and opens directly to wallet options.
+
+## 2. Auth Login Paths
+
+### Social OAuth login
+- [ ] Login with each enabled social provider succeeds from the modal.
+- [ ] Login works for default auth connections.
+- [ ] Login works for non-default auth connections configured by `authConnectionId`.
+- [ ] Grouped auth connections route to the correct provider and session.
+- [ ] Successful login resolves the modal flow and returns the expected connection.
+- [ ] In `connect-and-sign`, the flow reaches both connected and authorized states.
+- [ ] In `connect-only`, the flow completes without requiring the authorization step.
+
+### Social OAuth edge cases
+- [ ] Closing the popup fails gracefully and returns a user-cancelled style error.
+- [ ] Provider-side rejection returns a visible and actionable error.
+- [ ] Reopening the modal after a cancelled OAuth attempt still works.
+- [ ] Redirect-based auth, if configured, re-enters the app and restores the expected post-login state.
+
+### Email passwordless
+- [ ] Email OTP flow succeeds for a valid email.
+- [ ] OTP verification completes the auth flow and closes the modal correctly.
+- [ ] Resend OTP works and does not duplicate or corrupt session state.
+
+### Email passwordless edge cases
+- [ ] Invalid email is rejected before OTP submission.
+- [ ] Wrong OTP shows a recoverable error.
+- [ ] Expired OTP shows a recoverable error.
+- [ ] Captcha failure blocks the login attempt.
+- [ ] Closing the modal during the passwordless flow leaves no partial connected state.
+
+### SMS passwordless
+- [ ] SMS OTP flow succeeds for a valid phone number and country code.
+- [ ] OTP verification completes the auth flow and returns the expected connection.
+- [ ] Resend OTP works correctly.
+
+### SMS passwordless edge cases
+- [ ] Invalid phone number is rejected.
+- [ ] Wrong or expired OTP shows a recoverable error.
+- [ ] Captcha failure blocks the login attempt.
+- [ ] Closing the modal during the flow leaves the SDK in a reusable state.
+
+### Login method visibility and restrictions
+- [ ] Login methods respect `showOnModal`.
+- [ ] `loginMethodsOrder` is honored.
+- [ ] Restricted login methods that are intentionally excluded from the modal login grid do not appear unexpectedly.
+- [ ] Previous-login hint behavior is correct when enabled.
+
+## 3. External Wallet Login Paths
+
+### MetaMask
+- [ ] MetaMask connects successfully when the extension is installed.
+- [ ] MetaMask connects successfully through the desktop QR / handoff path when injection is unavailable and that path is expected.
+- [ ] In a mixed-chain app, MetaMask supports the expected multichain connection behavior.
+- [ ] Reopening the modal after a rejected MetaMask connection still works.
+
+### MetaMask edge cases
+- [ ] User rejection returns a clean error state.
+- [ ] A stale cached MetaMask session does not leave the modal stuck in connecting state.
+- [ ] Rehydration with a cached MetaMask session restores the correct chain context.
+
+### WalletConnect v2
+- [ ] WalletConnect v2 generates a QR code when selected from the modal.
+- [ ] Scanning the QR with a supported wallet completes connection successfully.
+- [ ] The background QR/session refresh path works when the modal is reopened.
+- [ ] The flow works in both `connect-only` and `connect-and-sign`.
+
+### WalletConnect v2 edge cases
+- [ ] Closing the modal during QR scan cancels the attempt cleanly.
+- [ ] Proposal expiry or wallet-side timeout returns the SDK to a reusable state.
+- [ ] Reopening the modal after a failed proposal shows a fresh QR/session.
+- [ ] A stale WalletConnect session is cleaned up instead of silently trapping the user.
+
+### Injected EVM wallets
+- [ ] Each discovered injected EVM wallet can connect from the modal.
+- [ ] Wallet-specific names and icons are rendered correctly.
+- [ ] Wallets added after app load appear when discovery refresh is expected.
+
+### Injected EVM wallet edge cases
+- [ ] Connect rejection leaves the modal and SDK reusable.
+- [ ] Chain add / switch prompts during connect behave correctly.
+- [ ] Rehydration failure clears the stale session instead of leaving a broken cached state.
+
+### Injected Solana wallets
+- [ ] Each discovered Solana wallet can connect from the modal.
+- [ ] Wallet Standard connections succeed with a supported Solana chain.
+- [ ] The returned active wallet and account details match the chosen wallet.
+
+### Injected Solana wallet edge cases
+- [ ] Unsupported Solana chain is rejected clearly.
+- [ ] Connect failure or wallet disconnect leaves the modal reusable.
+- [ ] Wallets with known proxy-sensitive behavior still connect correctly in supported integrations.
+
+### Coinbase Smart Wallet
+- [ ] Coinbase appears only when explicitly configured.
+- [ ] Coinbase connects successfully on supported EVM chains.
+- [ ] Coinbase chain switching works on supported chains.
+
+### Coinbase edge cases
+- [ ] Missing Coinbase connector configuration fails early.
+- [ ] Unsupported or invalid target chain fails cleanly.
+- [ ] Rehydration and disconnect behave like other external wallets.
+
+## 4. Multichain Login and Switching
+
+### Connect-time namespace selection
+- [ ] A multichain-compatible wallet with multiple namespaces shows the namespace picker.
+- [ ] The namespace picker displays the expected options for the configured app chains.
+- [ ] Choosing EVM connects the wallet against an EVM chain.
+- [ ] Choosing Solana connects the wallet against a Solana chain.
+- [ ] MetaMask follows its intended special-case behavior and does not show an unexpected namespace picker.
+
+### Runtime `switchChain`
+- [ ] Switching chains within the same namespace works for the active connector.
+- [ ] The active provider returned by the SDK reflects the new chain after switch.
+- [ ] `switchChain` updates downstream hooks/providers that depend on the active chain.
+
+### Cross-namespace switching
+- [ ] Auth supports switching between EVM and Solana when both are configured.
+- [ ] WalletConnect v2 supports cross-namespace switching when the session supports the target namespace.
+- [ ] Single-namespace connectors do not silently cross from EVM to Solana or vice versa.
+- [ ] For single-namespace connectors, the error clearly tells the user to disconnect and reconnect.
+
+### Multichain edge cases
+- [ ] Cached chain restore picks a valid chain for the active connector on reload.
+- [ ] Switching to the already-active chain is a no-op.
+- [ ] Invalid `chainId` fails clearly and leaves the prior connection intact.
+
+## 5. Rehydration
+
+### Primary session restore
+- [ ] Reload after Auth login restores the expected primary session.
+- [ ] Reload after MetaMask login restores the expected primary session.
+- [ ] Reload after WalletConnect v2 login restores the expected primary session.
+- [ ] Reload after injected EVM login restores the session when the wallet still grants access.
+- [ ] Reload after injected Solana login restores the session when the wallet still grants access.
+
+### Rehydration edge cases
+- [ ] Expired Auth session clears the cached connector and falls back to `READY`.
+- [ ] Missing WalletConnect session clears stale cache instead of leaving broken state.
+- [ ] Rehydration errors do not strand the modal in a loading state.
+- [ ] Rehydration restores the correct chain for multichain connectors.
+- [ ] Rehydration restores the active linked account when the session was switched away from primary.
+
+## 6. Disconnect and Cleanup
+
+### Standard disconnect
+- [ ] Logging out from an Auth session disconnects cleanly and returns the SDK to a reconnectable state.
+- [ ] Disconnecting an external wallet clears the active connection and allows a fresh reconnect.
+- [ ] After logout, the next connection starts from a clean modal state rather than reusing stale loading or error UI.
+
+### Cleanup behavior
+- [ ] Disconnect with cleanup tears down connector-specific state so the next connection reinitializes cleanly.
+- [ ] Disconnect without cleanup still returns the connector to a reusable ready state.
+- [ ] Closing a failed WalletConnect attempt cleans up any pending WC session.
+- [ ] Failed account linking attempts disconnect the temporary linking connector.
+- [ ] Failed account switching attempts do not corrupt the active connection.
+
+### Disconnect edge cases
+- [ ] Calling logout while not connected returns the expected error.
+- [ ] Wallet-side disconnect events are reflected in modal/UI state.
+- [ ] If a linked external wallet is disconnected or unlinked, its isolated connector state is removed.
+
+## 7. Consent Flow
+
+### Consent required
+- [ ] When consent is required, the modal enters the consent step after connect/authorize.
+- [ ] Accepting consent completes the login flow and unlocks plugin-dependent behavior.
+- [ ] Declining consent logs the user out and closes the modal.
+
+### Consent edge cases
+- [ ] Reopening the modal after consent decline starts from a clean state.
+- [ ] Consent errors are surfaced without leaving a half-connected session.
+
+## 8. Auth Actions Through Modal Integrations
+
+### MFA
+- [ ] `enableMFA()` works when the user is connected with Auth.
+- [ ] `manageMFA()` opens the correct management flow when the user is connected with Auth.
+- [ ] MFA is not offered or succeeds unexpectedly for external-wallet primary connections.
+
+### MFA edge cases
+- [ ] Calling MFA actions while not connected fails clearly.
+- [ ] Calling MFA actions on a non-Auth connector fails as unsupported.
+
+### Account linking
+- [ ] Linking an account works when the user is connected with Auth.
+- [ ] Linking works when the wallet is chosen from the modal picker.
+- [ ] Linking works when a connector is explicitly specified.
+- [ ] Linking an injected wallet shows the connecting and authorizing loader states correctly.
+- [ ] Linking through WalletConnect v2 shows the QR code and completes correctly.
+- [ ] Linking across namespaces chooses a compatible chain when the picked connector namespace differs from the current chain.
+
+### Account linking edge cases
+- [ ] Closing the picker before selecting a wallet returns a cancel-style error.
+- [ ] Closing the modal during WalletConnect QR scan cancels the link attempt and cleans up the temporary WC session.
+- [ ] Link failure disconnects the temporary connector and leaves the primary Auth session intact.
+- [ ] Starting a second account-linking picker while one is already open is blocked cleanly.
+
+### Account switching
+- [ ] Switching back to the primary Auth account updates the active account and connection correctly.
+- [ ] Switching to an already-connected linked external wallet reuses the existing connector instead of reconnecting.
+- [ ] Switching to a linked external wallet that is not currently connected re-establishes the isolated connector successfully.
+- [ ] Switching through WalletConnect v2 completes and keeps the linked connector available when required.
+- [ ] `CONNECTION_UPDATED`-driven consumers observe the new active connection.
+
+### Account switching edge cases
+- [ ] Switching to the already-active account is a no-op.
+- [ ] Switching fails clearly when the linked wallet connected in the wallet app does not match the target linked account.
+- [ ] Switch failure does not remove the previously active connection.
+
+### Account unlinking
+- [ ] Unlinking a linked external account succeeds and refreshes linked account state.
+- [ ] Unlinking disconnects the isolated connector for the removed linked account.
+
+### Account unlinking edge cases
+- [ ] Unlinking the primary account is blocked.
+- [ ] Unlinking the currently active linked account is blocked.
+- [ ] Unlinking a non-existent address fails clearly.
+
+## 9. Modal UX and Presentation
+
+### Modal states
+- [ ] The modal transitions correctly through initialized, connecting, connected, authorizing, consent, success, and error states.
+- [ ] Success screen behavior matches `hideSuccessScreen`.
+- [ ] Error display behavior matches `displayErrorsOnModal`.
+
+### Presentation checks
+- [ ] Theme selection works in light, dark, and auto modes when applicable.
+- [ ] Localization works for the supported languages used by the test plan.
+- [ ] Embedded widget mode renders in the target container and still supports the core login flows.
+
+## Suggested Smoke Pass
+
+Before a release, at minimum run:
+- [ ] Auth social login
+- [ ] Email passwordless
+- [ ] MetaMask connect
+- [ ] WalletConnect v2 QR connect and cancel
+- [ ] Rehydration after Auth and one external wallet
+- [ ] Logout after Auth and one external wallet
+- [ ] Multichain switch within namespace and cross namespace
+- [ ] Account link, switch, and unlink on an Auth-connected session
+
+## Related Source Areas
+
+- `packages/modal/src/modalManager.ts`
+- `packages/modal/src/ui/loginModal.tsx`
+- `packages/modal/src/ui/containers/Login/`
+- `packages/modal/src/ui/containers/ConnectWallet/`
+- `packages/modal/src/ui/containers/AccountLinking/`
+- `packages/no-modal/src/noModal.ts`
+- `packages/no-modal/src/connectors/`

--- a/docs/qa-checklist-no-modal.md
+++ b/docs/qa-checklist-no-modal.md
@@ -1,0 +1,366 @@
+# `@web3auth/no-modal` QA Checklist
+
+This checklist is for manual QA and focused regression testing of the no-modal SDK.
+
+Use it to validate:
+- connector-specific connect paths
+- session restore and cached state behavior
+- disconnect, cleanup, and cache reset paths
+- multichain switching, including cross-namespace behavior
+- Auth-only actions such as MFA, account linking, account switching, and unlinking
+
+## Recommended Test Matrix
+
+Run the relevant sections against:
+- desktop browser
+- mobile browser or mobile wallet handoff where the connector supports it
+- EVM-only app config
+- Solana-only app config
+- mixed EVM + Solana app config
+- `connect-and-sign` and `connect-only`
+- localStorage-backed state, cookie-backed state if used, and `initialState` restore if used
+
+## 1. SDK Initialization and Baseline State
+
+### Core initialization
+- [ ] `init()` succeeds with valid `clientId`, network, and chain config.
+- [ ] At least one valid chain is required and invalid chain config fails fast.
+- [ ] The SDK initializes the common provider and loads the expected connectors for the configured chains.
+- [ ] Optional custom connectors are available when passed in through `connectors`.
+
+### Initialization edge cases
+- [ ] Invalid `clientId` or network configuration fails clearly.
+- [ ] Empty chain configuration fails clearly.
+- [ ] Invalid chain namespace or invalid chain ID format fails clearly.
+- [ ] Aborted initialization does not leave partially initialized connector state behind.
+
+## 2. Connector Connection Paths
+
+### 2.1 Auth Connector
+
+### Social / OAuth login
+- [ ] `connectTo("auth", { authConnection })` succeeds for each supported configured provider.
+- [ ] `authConnectionId` selects the intended connection when multiple connections exist for the same provider.
+- [ ] `groupedAuthConnectionId` resolves the expected grouped provider configuration.
+- [ ] Popup mode works end to end.
+- [ ] Redirect mode, if used, restores correctly after returning to the app.
+
+### JWT / custom token login
+- [ ] Auth connection works when the app supplies `idToken` or equivalent extra login options.
+- [ ] Custom login resolves the expected user and provider state.
+
+### Auth connector edge cases
+- [ ] Unsupported or deprecated auth connections fail early.
+- [ ] Popup-close is surfaced as a user-cancelled error.
+- [ ] Missing auth connection config fails during init or connect with a clear error.
+- [ ] Invalid provider-specific params fail without corrupting SDK state.
+
+### Auth rehydration, disconnect, and cleanup
+- [ ] Cached Auth session rehydrates when the session is valid.
+- [ ] Expired Auth session triggers the rehydration error path.
+- [ ] `logout({ cleanup: false })` returns the connector to a reusable ready state.
+- [ ] `logout({ cleanup: true })` clears auth, ws-embed, and provider-backed session state.
+
+### 2.2 MetaMask Connector
+
+### Standard connect
+- [ ] `connectTo("metamask")` succeeds when MetaMask is available.
+- [ ] EVM-only apps connect successfully.
+- [ ] Mixed EVM + Solana apps establish the expected multichain session.
+
+### MetaMask edge cases
+- [ ] User rejection returns a clean error.
+- [ ] Reconnect after rejection still works.
+- [ ] Cached MetaMask session restores only when namespace and chain expectations are valid.
+
+### MetaMask rehydration, disconnect, and cleanup
+- [ ] Cached MetaMask session rehydrates into the expected active chain.
+- [ ] Disconnect returns the SDK to a reconnectable state.
+- [ ] Cleanup tears down the multichain client so a fresh reconnect reinitializes correctly.
+
+### 2.3 WalletConnect v2 Connector
+
+### Standard connect
+- [ ] `connectTo("wallet-connect-v2")` succeeds with a new WC session.
+- [ ] EVM session connects successfully.
+- [ ] Solana session connects successfully when the wallet/session supports it.
+- [ ] Mixed-chain session supports the expected namespaces.
+
+### WalletConnect v2 edge cases
+- [ ] Proposal expiry is handled without leaving the connector stuck.
+- [ ] Session deletion or expiry is reflected back into SDK state.
+- [ ] Reconnect after session expiry produces a clean new session.
+
+### WalletConnect v2 rehydration, disconnect, and cleanup
+- [ ] Cached WalletConnect session rehydrates when the session still exists.
+- [ ] Disconnect clears the WC session and returns the SDK to a reusable state.
+- [ ] Cleanup removes stale session data after cancellation, expiry, or manual disconnect.
+
+### 2.4 Injected EVM Connectors
+
+### Standard connect
+- [ ] Each discovered injected EVM wallet can connect through its normalized connector name.
+- [ ] Chain add / switch during connect succeeds when the wallet supports it.
+
+### Injected EVM edge cases
+- [ ] User rejection leaves the SDK reusable.
+- [ ] Missing provider or unavailable wallet fails cleanly.
+- [ ] Rehydration failure emits the rehydration path instead of a generic hard error.
+
+### Injected EVM rehydration, disconnect, and cleanup
+- [ ] Cached injected EVM state rehydrates only when wallet access is still granted.
+- [ ] Disconnect returns the connector to a reusable state.
+- [ ] Cleanup clears connector-held provider state for a fresh reconnect.
+
+### 2.5 Injected Solana Connectors
+
+### Standard connect
+- [ ] Each discovered Solana wallet can connect through its normalized connector name.
+- [ ] Connection succeeds only when the configured Solana chain is supported by that wallet.
+
+### Injected Solana edge cases
+- [ ] Unsupported Solana chain fails clearly.
+- [ ] Zero-account connect failure leaves the SDK reusable.
+- [ ] Disconnect from the wallet is reflected back into SDK state.
+
+### Injected Solana rehydration, disconnect, and cleanup
+- [ ] Cached injected Solana state rehydrates only when the wallet still grants access.
+- [ ] Disconnect returns the connector to a reusable state.
+- [ ] Cleanup resets the connector for a clean reconnect.
+
+### 2.6 Coinbase Smart Wallet
+
+### Standard connect
+- [ ] Coinbase works when explicitly added as a custom connector.
+- [ ] Connection succeeds on supported EVM chains.
+
+### Coinbase edge cases
+- [ ] Attempting to use Coinbase without adding the connector fails clearly.
+- [ ] Invalid chain config fails cleanly.
+- [ ] Rehydration and disconnect behave like a normal single-namespace EVM connector.
+
+### Coinbase rehydration, disconnect, and cleanup
+- [ ] Cached Coinbase state rehydrates when the session is still valid.
+- [ ] Disconnect returns the connector to a reusable state.
+- [ ] Cleanup tears down connector-held state for a clean reconnect.
+
+## 3. Authentication Mode Coverage
+
+### `connect-and-sign`
+- [ ] `connectTo()` resolves only after both connection and authorization complete.
+- [ ] External wallets complete the auth challenge and return a usable id token.
+- [ ] Auth connector returns its token info and reaches the authorized state.
+
+### `connect-only`
+- [ ] `connectTo()` resolves after the connection step only.
+- [ ] No unnecessary auth challenge is triggered.
+
+### Mode edge cases
+- [ ] Switching between modes across app reloads does not leave stale state.
+- [ ] A failed authorization step leaves the connector and cache in a recoverable state.
+
+## 4. Rehydration and Persisted State
+
+### Cached primary connector restore
+- [ ] Cached Auth session rehydrates when the session is still valid.
+- [ ] Cached MetaMask session rehydrates when wallet permission is still available.
+- [ ] Cached WalletConnect session rehydrates when the WC session still exists.
+- [ ] Cached injected EVM session rehydrates when the wallet still grants account access.
+- [ ] Cached injected Solana session rehydrates when the wallet still grants access.
+- [ ] Cached Coinbase session rehydrates when the connector still has a valid session.
+
+### Cached state edge cases
+- [ ] Expired Auth session triggers the rehydration error path and clears cache.
+- [ ] Missing WalletConnect session clears cache instead of leaving stale connector state.
+- [ ] Rehydration failure returns the SDK to `READY`.
+- [ ] Rehydration restores the correct chain ID when multiple app chains are configured.
+- [ ] Rehydration only auto-connects when namespace checks pass for the cached connector.
+
+### Linked-account restore
+- [ ] If the active account is a linked external wallet, reload restores that linked account as active.
+- [ ] The restored active account has the correct provider and chain.
+- [ ] `CONNECTION_UPDATED` consumers see the rehydrated active linked account state.
+
+### Persisted-state storage checks
+- [ ] localStorage state restore works.
+- [ ] Cookie-backed state restore works if the integration uses cookies.
+- [ ] Constructor `initialState` restore works if the integration uses it.
+
+## 5. Disconnect, Cleanup, and Cache Reset
+
+### `logout({ cleanup: false })`
+- [ ] Primary connector disconnects and the SDK returns to a reconnectable ready state.
+- [ ] The next connect attempt succeeds without requiring a full SDK re-create.
+
+### `logout({ cleanup: true })`
+- [ ] Primary connector tears down internal connector instances.
+- [ ] The next connect attempt forces a clean re-init of the connector.
+
+### `cleanup()`
+- [ ] Calling `cleanup()` tears down initialized connectors without corrupting SDK state.
+- [ ] Calling `cleanup()` after partial initialization does not throw unexpectedly.
+
+### `clearCache()`
+- [ ] `clearCache()` removes cached connector, tokens, active account, and chain state.
+- [ ] After `clearCache()`, the SDK behaves like a fresh session.
+
+### Disconnect and cleanup edge cases
+- [ ] Calling logout while not connected fails clearly.
+- [ ] Disconnecting the primary connector also removes connected linked-wallet connector state.
+- [ ] Connector `ERRORED` paths clear cache and do not leave stale active connection state behind.
+- [ ] Rehydration errors clear cache without forcing a full hard failure.
+
+## 6. Multichain and `switchChain`
+
+### Common chain switching
+- [ ] `switchChain()` is a no-op when the target chain is already active.
+- [ ] Invalid `chainId` fails clearly and does not change the active connection.
+
+### Disconnected chain switching
+- [ ] When no wallet is connected, `switchChain()` delegates to the common provider and updates the active chain.
+- [ ] The SDK uses the new active chain for the next connection attempt.
+
+### Connected multichain connectors
+- [ ] Auth can switch between configured EVM chains.
+- [ ] Auth can switch between configured Solana chains where supported.
+- [ ] Auth can switch across namespaces when both namespaces are configured.
+- [ ] WalletConnect v2 can switch within namespace and across namespaces when the session supports the target chain.
+- [ ] MetaMask multichain flow switches as expected for its supported namespaces.
+
+### Single-namespace connectors
+- [ ] Injected EVM wallets can switch only within EVM chains.
+- [ ] Coinbase can switch only within EVM chains.
+- [ ] Injected Solana wallets reject `switchChain()` as unsupported.
+
+### Cross-namespace guardrails
+- [ ] Single-namespace connectors cannot switch from EVM to Solana.
+- [ ] Single-namespace connectors cannot switch from Solana to EVM.
+- [ ] The cross-namespace failure message clearly tells the app/user to disconnect and reconnect with a compatible connector.
+
+### Multichain edge cases
+- [ ] Cached chain restore chooses a compatible chain for a multichain connector.
+- [ ] The auth token flow signs against the same active chain the controller is using after a switch.
+- [ ] Switching chain does not break downstream provider consumers.
+
+## 7. Auth Actions
+
+### 7.1 User and token retrieval
+
+### `getUserInfo()`
+- [ ] Returns user info when connected.
+- [ ] Returns linked accounts with the correct active-account annotation.
+
+### `getLinkedAccounts()`
+- [ ] Returns linked accounts only when connected with Auth.
+- [ ] Filters linked accounts correctly for the active namespace expectations.
+
+### `getConnectedAccountsWithProviders()`
+- [ ] Returns an empty list before authorization completes.
+- [ ] Returns the expected provider-backed account list after authorization.
+
+### `getAuthTokenInfo()`
+- [ ] Returns an id token when the connection supports authorization.
+- [ ] Uses the current active chain context for multichain connectors.
+
+### Retrieval edge cases
+- [ ] Calling these methods while not connected fails clearly.
+- [ ] Calling linked-account retrieval on a non-Auth primary connection fails as unsupported.
+
+### 7.2 MFA
+
+### `enableMFA()`
+- [ ] Works when connected through Auth.
+- [ ] Emits or reflects the expected success state in popup mode.
+
+### `manageMFA()`
+- [ ] Works when connected through Auth.
+
+### MFA edge cases
+- [ ] Calling MFA methods on a non-Auth connector fails as unsupported.
+- [ ] Calling MFA methods while disconnected fails clearly.
+- [ ] MFA failures do not corrupt the active session.
+
+### 7.3 Account linking
+
+### `linkAccount()`
+- [ ] Linking succeeds for an injected EVM wallet.
+- [ ] Linking succeeds for an injected Solana wallet.
+- [ ] Linking succeeds for WalletConnect v2.
+- [ ] Linking succeeds when the app specifies `chainId`.
+- [ ] Linking succeeds when the current SDK chain is used implicitly.
+
+### Account linking edge cases
+- [ ] Calling `linkAccount()` without `connectorName` on no-modal fails clearly.
+- [ ] Linking while not connected with Auth fails clearly.
+- [ ] Linking failure disconnects the temporary connector and leaves the primary Auth session intact.
+- [ ] Linking with an invalid or unavailable connector fails cleanly.
+
+### 7.4 Account unlinking
+
+### `unlinkAccount()`
+- [ ] Unlinking a linked external account succeeds.
+- [ ] Unlinking updates the id token and linked-account state.
+- [ ] Unlinking disconnects and removes the isolated connector for the unlinked account.
+
+### Account unlinking edge cases
+- [ ] Unlinking the primary account is blocked.
+- [ ] Unlinking the active linked account is blocked.
+- [ ] Unlinking an address that is not linked fails clearly.
+
+### 7.5 Account switching
+
+### `switchAccount()`
+- [ ] Switching back to the primary Auth account updates the active provider and chain correctly.
+- [ ] Switching to a linked external account that is already connected reuses the existing connector.
+- [ ] Switching to a linked external account that is not connected creates an isolated connector and connects it successfully.
+- [ ] Switching to a WalletConnect-linked account succeeds with the correct account and chain.
+- [ ] The SDK emits or reflects the expected connection update for downstream consumers.
+
+### Account switching edge cases
+- [ ] Switching to the already-active account is a no-op.
+- [ ] Switching while disconnected fails clearly.
+- [ ] Switching fails clearly if the wallet account connected in the wallet app does not match the target linked account.
+- [ ] Switch failure does not destroy the previously active connection.
+- [ ] Cross-namespace account switching resolves the correct active chain ID for the target account.
+
+## 8. Connector Event and Error Handling
+
+### Event coverage
+- [ ] `READY` fires on successful initialization.
+- [ ] `CONNECTING` fires when a connection starts.
+- [ ] `CONNECTED` fires on successful wallet connection.
+- [ ] `AUTHORIZING` and `AUTHORIZED` fire in `connect-and-sign` flows.
+- [ ] `DISCONNECTED` fires on disconnect.
+- [ ] `REHYDRATION_ERROR` fires on stale or invalid cached restore.
+- [ ] `CACHE_CLEAR` is observable when the SDK clears invalid cached state.
+- [ ] `CONNECTION_UPDATED` is observable after account switching or linked-account restore.
+
+### Error path checks
+- [ ] Connector failure moves the SDK back to a recoverable state.
+- [ ] Connector `ERRORED` paths do not leave stale providers exposed to consumers.
+- [ ] A failed linked-wallet path does not corrupt the primary Auth connection.
+
+## Suggested Smoke Pass
+
+Before a release, at minimum run:
+- [ ] Auth social login in both auth modes
+- [ ] MetaMask connect, reload, and logout
+- [ ] WalletConnect v2 connect, reload, and disconnect
+- [ ] One injected EVM wallet connect and reload
+- [ ] One injected Solana wallet connect and reload
+- [ ] `switchChain()` within namespace and across namespace
+- [ ] `enableMFA()` and `manageMFA()` on Auth
+- [ ] `linkAccount()`, `switchAccount()`, and `unlinkAccount()`
+- [ ] `clearCache()` followed by a fresh connect
+
+## Related Source Areas
+
+- `packages/no-modal/src/noModal.ts`
+- `packages/no-modal/src/connectors/auth-connector/`
+- `packages/no-modal/src/connectors/metamask-connector/`
+- `packages/no-modal/src/connectors/wallet-connect-v2-connector/`
+- `packages/no-modal/src/connectors/injected-evm-connector/`
+- `packages/no-modal/src/connectors/injected-solana-connector/`
+- `packages/no-modal/src/connectors/coinbase-connector/`
+- `packages/no-modal/src/react/`
+- `packages/no-modal/src/vue/`

--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -885,10 +885,13 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
     try {
       const connector = this.getConnector(params.connector as WALLET_CONNECTOR_TYPE, params.loginParams?.chainNamespace);
       // auto-connect WalletConnect in background to generate QR code URI without interfering with user's selected connection
-      const shouldStartConnectionInBackground = connector.name === WALLET_CONNECTORS.WALLET_CONNECT_V2;
+      const shouldStartConnectionInBackground = connector?.name === WALLET_CONNECTORS.WALLET_CONNECT_V2;
       if (shouldStartConnectionInBackground) {
         const initialChain = this.getInitialChainIdForConnector(connector);
-        await connector.connect({ chainId: initialChain.chainId });
+        await connector.connect({
+          chainId: initialChain.chainId,
+          getAuthTokenInfo: this.options.initialAuthenticationMode === CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN,
+        });
       } else {
         await this.connectTo(params.connector as WALLET_CONNECTOR_TYPE, params.loginParams, LOGIN_MODE.MODAL);
       }
@@ -916,7 +919,10 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
         // refreshing session for wallet connect whenever modal is opened.
         try {
           const initialChain = this.getInitialChainIdForConnector(wcConnector);
-          wcConnector.connect({ chainId: initialChain.chainId });
+          wcConnector.connect({
+            chainId: initialChain.chainId,
+            getAuthTokenInfo: this.options.initialAuthenticationMode === CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN,
+          });
         } catch (error) {
           log.error(`Error while disconnecting to wallet connect in core`, error);
         }

--- a/packages/no-modal/src/base/connector/interfaces.ts
+++ b/packages/no-modal/src/base/connector/interfaces.ts
@@ -102,6 +102,7 @@ export interface Connection {
   readonly ethereumProvider: IProvider | null;
   readonly solanaWallet: Wallet | null;
   readonly connectorName: WALLET_CONNECTOR_TYPE | string;
+  readonly connectorNamespace: ConnectorNamespaceType;
 }
 
 export interface IConnector<T> extends SafeEventEmitter {

--- a/packages/no-modal/src/base/interfaces.ts
+++ b/packages/no-modal/src/base/interfaces.ts
@@ -2,7 +2,7 @@ import { type BUTTON_POSITION_TYPE } from "@toruslabs/base-controllers";
 import type { SmartAccountEipStandardType, SmartAccountType } from "@toruslabs/ethereum-controllers";
 import { AuthConnectionConfigItem, type WhiteLabelData } from "@web3auth/auth";
 
-import { type ChainNamespaceType, type CustomChainConfig } from "./chain/IChainInterface";
+import { type ChainNamespaceType, ConnectorNamespaceType, type CustomChainConfig } from "./chain/IChainInterface";
 import { LinkedAccountInfo } from "./connector";
 import { LOGIN_MODE, MODAL_SIGN_IN_METHODS, SMART_ACCOUNT_WALLET_SCOPE, WIDGET_TYPE } from "./constants";
 import { WALLET_CONNECTOR_TYPE } from "./wallet";
@@ -14,6 +14,7 @@ export interface WhitelistResponse {
 
 export interface IWeb3AuthState {
   cachedConnector: string | null;
+  cachedConnectorNamespace: ConnectorNamespaceType | null;
   primaryConnectorName: WALLET_CONNECTOR_TYPE | null;
   currentChainId: string;
   idToken: string | null;

--- a/packages/no-modal/src/connectors/auth-connector/authConnector.ts
+++ b/packages/no-modal/src/connectors/auth-connector/authConnector.ts
@@ -42,7 +42,6 @@ import {
   CHAIN_NAMESPACES,
   citadelServerUrl,
   cloneDeep,
-  CONNECTED_EVENT_DATA,
   CONNECTED_STATUSES,
   type Connection,
   CONNECTOR_CATEGORY,
@@ -266,7 +265,12 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
     this.emit(CONNECTOR_EVENTS.CONNECTING, { ...params, connector: WALLET_CONNECTORS.AUTH });
     try {
       await this.connectWithProvider(params);
-      return { ethereumProvider: this.provider, solanaWallet: this._solanaWallet, connectorName: this.name };
+      return {
+        ethereumProvider: this.provider,
+        solanaWallet: this._solanaWallet,
+        connectorName: this.name,
+        connectorNamespace: this.connectorNamespace,
+      };
     } catch (error: unknown) {
       log.error("Failed to connect with auth provider", error);
       // ready again to be connected
@@ -927,6 +931,7 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
       );
     }
 
+    const connectorNamespace = this.connectorNamespace;
     // setup WS embed if chainNamespace is EIP155 or SOLANA
     if (chainNamespace === CHAIN_NAMESPACES.EIP155 || chainNamespace === CHAIN_NAMESPACES.SOLANA) {
       // wait for ws embed instance to be ready.
@@ -952,7 +957,8 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
             reconnected: this.rehydrated,
             ethereumProvider: this.provider,
             solanaWallet: this._solanaWallet,
-          } as CONNECTED_EVENT_DATA);
+            connectorNamespace,
+          });
 
           if (params.getAuthTokenInfo) {
             await this.getAuthTokenInfo();
@@ -970,7 +976,8 @@ class AuthConnector extends BaseConnector<AuthLoginParams> implements IAuthConne
           ethereumProvider: this.provider,
           solanaWallet: this._solanaWallet,
           reconnected: this.rehydrated,
-        } as CONNECTED_EVENT_DATA);
+          connectorNamespace,
+        });
       }
     }
   }

--- a/packages/no-modal/src/connectors/coinbase-connector/coinbaseConnector.ts
+++ b/packages/no-modal/src/connectors/coinbase-connector/coinbaseConnector.ts
@@ -6,7 +6,6 @@ import {
   BaseConnectorSettings,
   CHAIN_NAMESPACES,
   ChainNamespaceType,
-  CONNECTED_EVENT_DATA,
   Connection,
   CONNECTOR_CATEGORY,
   CONNECTOR_CATEGORY_TYPE,
@@ -120,13 +119,14 @@ class CoinbaseConnector extends BaseEvmConnector<void> {
         reconnected: this.rehydrated,
         ethereumProvider: this.provider,
         solanaWallet: null,
-      } as CONNECTED_EVENT_DATA);
+        connectorNamespace: this.connectorNamespace,
+      });
 
       if (getAuthTokenInfo) {
         await this.getAuthTokenInfo();
       }
 
-      return { ethereumProvider: this.provider, solanaWallet: null, connectorName: this.name };
+      return { ethereumProvider: this.provider, solanaWallet: null, connectorName: this.name, connectorNamespace: this.connectorNamespace };
     } catch (error) {
       // ready again to be connected
       this.status = CONNECTOR_STATUS.READY;

--- a/packages/no-modal/src/connectors/injected-evm-connector/injectedEvmConnector.ts
+++ b/packages/no-modal/src/connectors/injected-evm-connector/injectedEvmConnector.ts
@@ -6,7 +6,6 @@ import {
   BaseConnectorSettings,
   CHAIN_NAMESPACES,
   ChainNamespaceType,
-  CONNECTED_EVENT_DATA,
   Connection,
   CONNECTOR_CATEGORY,
   CONNECTOR_CATEGORY_TYPE,
@@ -109,18 +108,20 @@ class InjectedEvmConnector extends BaseEvmConnector<void> {
         }
       };
       this.injectedProvider.on("accountsChanged", accountDisconnectHandler);
+      const connectorNamespace = this.connectorNamespace;
       this.emit(CONNECTOR_EVENTS.CONNECTED, {
         connectorName: this.name,
         reconnected: this.rehydrated,
         ethereumProvider: this.injectedProvider,
         solanaWallet: null,
-      } as CONNECTED_EVENT_DATA);
+        connectorNamespace,
+      });
 
       if (getAuthTokenInfo) {
         await this.getAuthTokenInfo();
       }
 
-      return { ethereumProvider: this.injectedProvider, solanaWallet: null, connectorName: this.name };
+      return { ethereumProvider: this.injectedProvider, solanaWallet: null, connectorName: this.name, connectorNamespace };
     } catch (error) {
       // ready again to be connected
       this.status = CONNECTOR_STATUS.READY;

--- a/packages/no-modal/src/connectors/injected-solana-connector/walletStandardConnector.ts
+++ b/packages/no-modal/src/connectors/injected-solana-connector/walletStandardConnector.ts
@@ -26,7 +26,6 @@ import {
   BaseConnectorSettings,
   CHAIN_NAMESPACES,
   ChainNamespaceType,
-  CONNECTED_EVENT_DATA,
   Connection,
   CONNECTOR_CATEGORY,
   CONNECTOR_CATEGORY_TYPE,
@@ -122,18 +121,20 @@ export class WalletStandardConnector extends BaseSolanaConnector<void> {
       if (this.wallet.accounts.length === 0) throw WalletLoginError.connectionError();
 
       this.status = CONNECTOR_STATUS.CONNECTED;
+      const connectorNamespace = this.connectorNamespace;
       this.emit(CONNECTOR_EVENTS.CONNECTED, {
         connectorName: this.name,
         reconnected: this.rehydrated,
         ethereumProvider: null,
         solanaWallet: this.solanaWallet,
-      } as CONNECTED_EVENT_DATA);
+        connectorNamespace,
+      });
 
       if (getAuthTokenInfo) {
         await this.getAuthTokenInfo();
       }
 
-      return { ethereumProvider: null, solanaWallet: this.solanaWallet, connectorName: this.name };
+      return { ethereumProvider: null, solanaWallet: this.solanaWallet, connectorName: this.name, connectorNamespace };
     } catch (error: unknown) {
       // ready again to be connected
       this.status = CONNECTOR_STATUS.READY;

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -327,7 +327,7 @@ class MetaMaskConnector extends BaseConnector<void> {
 
       // sync the chain state after connect
       // metamask might not be connected to the requested chain, so we need to sync the chain state to/from Web3Auth state after connect.
-      await this.syncChainStateAfterConnect(chainConfig);
+      await this.syncChainState(chainConfig);
 
       // check if connected
       if (this.multichainClient.status !== "connected") {
@@ -437,39 +437,43 @@ class MetaMaskConnector extends BaseConnector<void> {
 
   public async switchChain(params: { chainId: string }, init = false): Promise<void> {
     super.checkSwitchChainRequirements(params, init);
+    await this.ensureInitialized();
 
     const targetChainConfig = this.coreOptions.chains.find((c) => c.chainId === params.chainId);
-    if (targetChainConfig?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
-      // no need to switch chain for Solana
+    if (!targetChainConfig) throw WalletLoginError.connectionError("Chain config is not available");
+
+    if (targetChainConfig.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
+      if (!this.solanaWallet) {
+        throw WalletLoginError.unsupportedOperation("switchChain requires a Solana client, but no Solana chains are configured.");
+      }
+
+      // For solana case, we don't have the `switchChain` method like `evmClient`.
+      // So, we just need to sync with the connected solana chain to the Web3Auth state.
+      await this.syncChainState(targetChainConfig, true);
       return;
     }
-
-    await this.ensureInitialized();
 
     if (!this.evmClient) {
       throw WalletLoginError.unsupportedOperation("switchChain requires an EVM client, but no EVM chains are configured.");
     }
 
-    const chainConfig = this.coreOptions.chains.find(
-      (x) => x.chainId === params.chainId && ([CHAIN_NAMESPACES.EIP155] as ChainNamespaceType[]).includes(x.chainNamespace)
-    );
-
-    const chainConfiguration = chainConfig
+    const chainConfiguration = targetChainConfig
       ? {
           chainId: params.chainId,
-          chainName: chainConfig.displayName,
-          rpcUrls: [chainConfig.rpcTarget],
-          blockExplorerUrls: chainConfig.blockExplorerUrl ? [chainConfig.blockExplorerUrl] : undefined,
+          chainName: targetChainConfig.displayName,
+          rpcUrls: [targetChainConfig.rpcTarget],
+          blockExplorerUrls: targetChainConfig.blockExplorerUrl ? [targetChainConfig.blockExplorerUrl] : undefined,
           nativeCurrency: {
-            name: chainConfig.tickerName,
-            symbol: chainConfig.ticker,
-            decimals: chainConfig.decimals || 18,
+            name: targetChainConfig.tickerName,
+            symbol: targetChainConfig.ticker,
+            decimals: targetChainConfig.decimals || 18,
           },
-          iconUrls: chainConfig.logo ? [chainConfig.logo] : undefined,
+          iconUrls: targetChainConfig.logo ? [targetChainConfig.logo] : undefined,
         }
       : undefined;
 
     await this.evmClient.switchChain({ chainId: params.chainId as Hex, chainConfiguration });
+    this.updateConnectorData({ chainId: params.chainId });
   }
 
   public async generateChallengeAndSign(
@@ -539,7 +543,12 @@ class MetaMaskConnector extends BaseConnector<void> {
     await this.initializationPromise;
   }
 
-  private async syncChainStateAfterConnect(chainConfig: CustomChainConfig) {
+  /**
+   * Syncs the chain state with the Web3Auth state.
+   * @param chainConfig - The chain config to sync.
+   * @param forceConnectorUpdate - Whether to force update the connector data.
+   */
+  private async syncChainState(chainConfig: CustomChainConfig, forceConnectorUpdate = false) {
     // EVM connectors can switch chains, so align the wallet with the requested chain
     // before Web3Auth persists the active chain in controller state.
     if (chainConfig.chainNamespace === CHAIN_NAMESPACES.EIP155 && this.evmProvider?.chainId !== chainConfig.chainId) {
@@ -557,11 +566,13 @@ class MetaMaskConnector extends BaseConnector<void> {
           throw WalletLoginError.connectionError("Connected chain is not available in the chains config");
         }
 
-        if (connectedChainConfig.chainId !== chainConfig.chainId) {
+        if (connectedChainConfig.chainId !== chainConfig.chainId || forceConnectorUpdate) {
           // since, switchChain is not supported for solana (in metamask connect),
           // we will make use of the connector data to update the Web3Auth state.
           this.updateConnectorData({ chainId: connectedChainConfig.chainId });
         }
+      } else if (forceConnectorUpdate) {
+        this.updateConnectorData({ chainId: chainConfig.chainId });
       }
     }
   }

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -253,6 +253,14 @@ class MetaMaskConnector extends BaseConnector<void> {
     if (coreStatus === "connected" && options.autoConnect) {
       this.status = CONNECTOR_STATUS.CONNECTED;
       this.rehydrated = true;
+
+      // Force sync the chain state before connect with rehydrated state.
+      // during rehydration, `createEVMClient` (from above) cause re-creating session for connected the evm provider,
+      // triggering `switchChain` internally and unintentionally update the connector data with the new chain id.
+      // This creates issue in rehydration flow, where Web3Auth connects to the incorrect chain id, not the rehydrated chain id.
+      // Force sync the chain state with the rehydrated chain id to avoid this issue.
+      await this.syncChainState(chainConfig, true);
+
       this.emit(CONNECTOR_EVENTS.CONNECTED, {
         connectorName: WALLET_CONNECTORS.METAMASK,
         reconnected: true,
@@ -260,13 +268,6 @@ class MetaMaskConnector extends BaseConnector<void> {
         solanaWallet: this.solanaProvider,
       });
       if (options.getAuthTokenInfo) await this.getAuthTokenInfo(options.chainId);
-
-      // Force sync the chain state after connect.
-      // during rehydration, `createEVMClient` (from above) cause re-creating session for the evm provider,
-      // trigger `switchChain` and unintentionally update the connector data with the new chain id.
-      // This creates issue in rehydration flow, where Web3Auth connects to the incorrect chain id, not the rehydrated chain id.
-      // Force sync the chain state with the rehydrated chain id to avoid this issue.
-      await this.syncChainState(chainConfig, true);
     } else if (coreStatus === "connected" || coreStatus === "loaded" || coreStatus === "disconnected" || coreStatus === "pending") {
       this.status = CONNECTOR_STATUS.READY;
       this.emit(CONNECTOR_EVENTS.READY, WALLET_CONNECTORS.METAMASK);

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -260,6 +260,13 @@ class MetaMaskConnector extends BaseConnector<void> {
         solanaWallet: this.solanaProvider,
       });
       if (options.getAuthTokenInfo) await this.getAuthTokenInfo(options.chainId);
+
+      // Force sync the chain state after connect.
+      // during rehydration, `createEVMClient` (from above) cause re-creating session for the evm provider,
+      // trigger `switchChain` and unintentionally update the connector data with the new chain id.
+      // This creates issue in rehydration flow, where Web3Auth connects to the incorrect chain id, not the rehydrated chain id.
+      // Force sync the chain state with the rehydrated chain id to avoid this issue.
+      await this.syncChainState(chainConfig, true);
     } else if (coreStatus === "connected" || coreStatus === "loaded" || coreStatus === "disconnected" || coreStatus === "pending") {
       this.status = CONNECTOR_STATUS.READY;
       this.emit(CONNECTOR_EVENTS.READY, WALLET_CONNECTORS.METAMASK);

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -18,7 +18,6 @@ import {
   CHAIN_NAMESPACES,
   type ChainNamespaceType,
   citadelServerUrl,
-  CONNECTED_EVENT_DATA,
   type Connection,
   CONNECTOR_CATEGORY,
   type CONNECTOR_CATEGORY_TYPE,
@@ -266,6 +265,7 @@ class MetaMaskConnector extends BaseConnector<void> {
         reconnected: true,
         ethereumProvider: this.evmProvider,
         solanaWallet: this.solanaProvider,
+        connectorNamespace: this.connectorNamespace,
       });
       if (options.getAuthTokenInfo) await this.getAuthTokenInfo(options.chainId);
     } else if (coreStatus === "connected" || coreStatus === "loaded" || coreStatus === "disconnected" || coreStatus === "pending") {
@@ -358,13 +358,19 @@ class MetaMaskConnector extends BaseConnector<void> {
         reconnected: this.rehydrated,
         ethereumProvider: this.evmProvider,
         solanaWallet: this.solanaProvider,
-      } as CONNECTED_EVENT_DATA);
+        connectorNamespace: this.connectorNamespace,
+      });
 
       if (getAuthTokenInfo) {
         await this.getAuthTokenInfo(chainId);
       }
 
-      return { ethereumProvider: this.evmProvider, solanaWallet: this.solanaProvider, connectorName: this.name };
+      return {
+        ethereumProvider: this.evmProvider,
+        solanaWallet: this.solanaProvider,
+        connectorName: this.name,
+        connectorNamespace: this.connectorNamespace,
+      };
     } catch (error) {
       // Ready again to be connected
       this.status = CONNECTOR_STATUS.READY;

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -259,7 +259,7 @@ class MetaMaskConnector extends BaseConnector<void> {
       // triggering `switchChain` internally and unintentionally update the connector data with the new chain id.
       // This creates issue in rehydration flow, where Web3Auth connects to the incorrect chain id, not the rehydrated chain id.
       // Force sync the chain state with the rehydrated chain id to avoid this issue.
-      await this.syncChainState(chainConfig, true);
+      await this.forceSyncChainState(chainConfig);
 
       this.emit(CONNECTOR_EVENTS.CONNECTED, {
         connectorName: WALLET_CONNECTORS.METAMASK,
@@ -335,7 +335,7 @@ class MetaMaskConnector extends BaseConnector<void> {
 
       // sync the chain state after connect
       // metamask might not be connected to the requested chain, so we need to sync the chain state to/from Web3Auth state after connect.
-      await this.syncChainState(chainConfig);
+      await this.forceSyncChainState(chainConfig);
 
       // check if connected
       if (this.multichainClient.status !== "connected") {
@@ -457,7 +457,7 @@ class MetaMaskConnector extends BaseConnector<void> {
 
       // For solana case, we don't have the `switchChain` method like `evmClient`.
       // So, we just need to sync with the connected solana chain to the Web3Auth state.
-      await this.syncChainState(targetChainConfig, true);
+      await this.forceSyncChainState(targetChainConfig);
       return;
     }
 
@@ -554,9 +554,8 @@ class MetaMaskConnector extends BaseConnector<void> {
   /**
    * Syncs the chain state with the Web3Auth state.
    * @param chainConfig - The chain config to sync.
-   * @param forceConnectorUpdate - Whether to force update the connector data.
    */
-  private async syncChainState(chainConfig: CustomChainConfig, forceConnectorUpdate = false) {
+  private async forceSyncChainState(chainConfig: CustomChainConfig) {
     // EVM connectors can switch chains, so align the wallet with the requested chain
     // before Web3Auth persists the active chain in controller state.
     if (chainConfig.chainNamespace === CHAIN_NAMESPACES.EIP155 && this.evmProvider?.chainId !== chainConfig.chainId) {
@@ -574,12 +573,6 @@ class MetaMaskConnector extends BaseConnector<void> {
           throw WalletLoginError.connectionError("Connected chain is not available in the chains config");
         }
 
-        if (connectedChainConfig.chainId !== chainConfig.chainId || forceConnectorUpdate) {
-          // since, switchChain is not supported for solana (in metamask connect),
-          // we will make use of the connector data to update the Web3Auth state.
-          this.updateConnectorData({ chainId: connectedChainConfig.chainId });
-        }
-      } else if (forceConnectorUpdate) {
         this.updateConnectorData({ chainId: chainConfig.chainId });
       }
     }

--- a/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
+++ b/packages/no-modal/src/connectors/wallet-connect-v2-connector/walletConnectV2Connector.ts
@@ -16,7 +16,6 @@ import {
   CHAIN_NAMESPACES,
   ChainNamespaceType,
   citadelServerUrl,
-  CONNECTED_EVENT_DATA,
   type Connection,
   CONNECTOR_CATEGORY,
   CONNECTOR_CATEGORY_TYPE,
@@ -205,17 +204,18 @@ class WalletConnectV2Connector extends BaseConnector<void> {
         }
       };
 
+      const connectorNamespace = this.connectorNamespace;
       // if already connected
       if (this.connected) {
         await this.onConnectHandler({ chain: chainConfig, getAuthTokenInfo });
-        return { ethereumProvider: this.provider, solanaWallet: this._solanaWallet, connectorName: this.name };
+        return { ethereumProvider: this.provider, solanaWallet: this._solanaWallet, connectorName: this.name, connectorNamespace };
       }
 
       if (this.status !== CONNECTOR_STATUS.CONNECTING) {
         await this.createNewSession({ chainConfig, trackCompletionEvents, getAuthTokenInfo });
       }
 
-      return { ethereumProvider: this.provider, solanaWallet: this._solanaWallet, connectorName: this.name };
+      return { ethereumProvider: this.provider, solanaWallet: this._solanaWallet, connectorName: this.name, connectorNamespace };
     } catch (error) {
       log.error("Wallet connect v2 connector error while connecting", error);
       // ready again to be connected
@@ -479,7 +479,8 @@ class WalletConnectV2Connector extends BaseConnector<void> {
       reconnected: this.rehydrated,
       ethereumProvider: this.provider,
       solanaWallet: this._solanaWallet,
-    } as CONNECTED_EVENT_DATA);
+      connectorNamespace: this.connectorNamespace,
+    });
 
     if (getAuthTokenInfo) {
       await this.getAuthTokenInfo();

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1174,7 +1174,6 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
         if (this.status !== CONNECTOR_STATUS.CONSENT_REQUIRING && this.status !== CONNECTOR_STATUS.AUTHORIZED) {
           this.status = CONNECTOR_STATUS.CONNECTED;
         }
-        log.debug("connected", this.status, this.primaryConnectorName);
         // Defer plugin connection until consent is accepted; otherwise plugins would start before the consent step completes.
         // `completeConsentAcceptance` connects the plugins once the user accepts the consent.
         if (!pendingUserConsent) {

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -42,6 +42,7 @@ import {
   CONNECTOR_NAMESPACES,
   CONNECTOR_STATUS,
   type CONNECTOR_STATUS_TYPE,
+  ConnectorNamespaceType,
   type ConnectorParams,
   type CustomChainConfig,
   DISCONNECTED_EVENT_DATA,
@@ -139,6 +140,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     accessToken: null,
     refreshToken: null,
     activeAccount: null,
+    cachedConnectorNamespace: null,
   };
 
   constructor(options: IWeb3AuthCoreOptions, initialState?: Partial<IWeb3AuthState>) {
@@ -360,6 +362,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     await this.setState({
       primaryConnectorName: null,
       cachedConnector: null,
+      cachedConnectorNamespace: null,
       currentChainId: null,
       idToken: null,
       accessToken: null,
@@ -1158,7 +1161,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       await this.setState({
         primaryConnectorName: data.connectorName as WALLET_CONNECTOR_TYPE,
       });
-      this.cacheWallet(data.connectorName);
+      this.cacheWallet(data.connectorName, data.connectorNamespace);
 
       const isConnectAndSign = this.coreOptions.initialAuthenticationMode === CONNECTOR_INITIAL_AUTHENTICATION_MODE.CONNECT_AND_SIGN;
       const pendingUserConsent = this.consentRequired && !this.state.hasUserConsent;
@@ -1354,7 +1357,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
   }
 
   protected checkIfAutoConnect(connector: IConnector<unknown>): boolean {
-    let autoConnect = this.cachedConnector === connector.name;
+    let autoConnect = this.cachedConnector === connector.name && this.state.cachedConnectorNamespace === connector.connectorNamespace;
     if (autoConnect && this.currentChain?.chainNamespace) {
       if (connector.connectorNamespace === CONNECTOR_NAMESPACES.MULTICHAIN) autoConnect = true;
       else autoConnect = connector.connectorNamespace === this.currentChain.chainNamespace;
@@ -1610,6 +1613,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       ethereumProvider: connectedWallet.signingProvider,
       solanaWallet: connectedWallet.solanaWallet ?? null,
       connectorName: connectedWallet.connector.name,
+      connectorNamespace: connectedWallet.connector.connectorNamespace,
     };
   }
 
@@ -1766,11 +1770,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     if (!connection) {
       throw WalletLoginError.connectionError("Failed to resolve the active connection after switching accounts.");
     }
-    this.emit(CONNECTOR_EVENTS.CONNECTION_UPDATED, {
-      ethereumProvider: connection.ethereumProvider,
-      solanaWallet: connection.solanaWallet,
-      connectorName: connection.connectorName,
-    });
+    this.emit(CONNECTOR_EVENTS.CONNECTION_UPDATED, connection);
   }
 
   private isActiveConnectorEventSource(connector: IConnector<unknown>): boolean {
@@ -1862,9 +1862,10 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     }
   }
 
-  private async cacheWallet(walletName: string): Promise<void> {
+  private async cacheWallet(walletName: string, connectorNamespace: ConnectorNamespaceType): Promise<void> {
     await this.setState({
       cachedConnector: walletName,
+      cachedConnectorNamespace: connectorNamespace,
     });
   }
 

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1376,7 +1376,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
 
     // if the connector is a multi-chain connector and a default chain id is set, use the default chain id
     if (isMultiChainConnector && defaultChainId) {
-      initialChain = this.coreOptions.chains.find((chain) => chain.chainId === defaultChainId);
+      initialChain = this.coreOptions.chains.find((chain) => chain.chainId === defaultChainId) || this.currentChain;
     } else if (initialChain?.chainNamespace !== connector.connectorNamespace && connector.connectorNamespace !== CONNECTOR_NAMESPACES.MULTICHAIN) {
       initialChain = this.coreOptions.chains.find((x) => x.chainNamespace === connector.connectorNamespace);
     }

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1287,7 +1287,18 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       // External wallets can resolve to a different active chain than the requested one,
       // so let connector-reported chain updates reconcile Web3Auth state after connect.
       if (typeof data?.data === "object" && data?.data !== null && "chainId" in data.data && typeof data.data.chainId === "string") {
+        const previousChain = this.currentChain;
         await this.setCurrentChain(data.data.chainId);
+        const currentChain = this.currentChain;
+        const connectorEthereumProvider = connector.provider;
+        if (
+          previousChain?.chainNamespace !== currentChain?.chainNamespace &&
+          currentChain?.chainNamespace === CHAIN_NAMESPACES.EIP155 &&
+          connectorEthereumProvider
+        ) {
+          // from sol -> evm namespace switch, we need to re-create AccountAbstractionProvider
+          await this.bindPrimaryEthereumSigningProxy(connectorEthereumProvider, connector.name);
+        }
       }
       log.debug("connector data updated", data);
       this.emit(CONNECTOR_EVENTS.CONNECTOR_DATA_UPDATED, data);
@@ -1880,7 +1891,12 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
 
   private async bindPrimaryEthereumSigningProxy(ethereumProvider: IProvider, connectorName: WALLET_CONNECTOR_TYPE | string): Promise<void> {
     if (!this.commonJRPCProvider) throw WalletInitializationError.notFound(`CommonJrpcProvider not found`);
-    let finalProvider = (ethereumProvider as IBaseProvider<unknown>)?.provider || (ethereumProvider as SafeEventEmitterProvider);
+    const primaryConnectorProvider = connectorName === this.primaryConnectorName ? this.primaryConnector?.provider : null;
+    const baseEthereumProvider =
+      ethereumProvider === this.commonJRPCProvider || ethereumProvider === this.aaProvider
+        ? (primaryConnectorProvider ?? ethereumProvider)
+        : ethereumProvider;
+    let finalProvider = (baseEthereumProvider as IBaseProvider<unknown>)?.provider || (baseEthereumProvider as SafeEventEmitterProvider);
     const { accountAbstractionConfig } = this.coreOptions;
     const is7702 = accountAbstractionConfig?.smartAccountEipStandard === SMART_ACCOUNT_EIP_STANDARD["EIP_7702"];
     const isAaSupportedForCurrentChain =
@@ -1890,7 +1906,7 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     // setup AA provider if AA is enabled (skip for EIP-7702; 7702 uses EOA + 5792/7702 RPC only)
     if (!is7702 && isAaSupportedForCurrentChain && (connectorName === WALLET_CONNECTORS.AUTH || this.coreOptions.useAAWithExternalWallet)) {
       const { accountAbstractionProvider, toEoaProvider } = await import("./providers/account-abstraction-provider");
-      const eoaProvider: IProvider = connectorName === WALLET_CONNECTORS.AUTH ? await toEoaProvider(ethereumProvider) : ethereumProvider;
+      const eoaProvider: IProvider = connectorName === WALLET_CONNECTORS.AUTH ? await toEoaProvider(baseEthereumProvider) : baseEthereumProvider;
       const aaChainIds = new Set(accountAbstractionConfig?.chains?.map((chain) => chain.chainId) || []);
       const aaProvider = await accountAbstractionProvider({
         accountAbstractionConfig,

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -960,7 +960,9 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
     });
 
     // sync chainId
-    this.commonJRPCProvider.on("chainChanged", async (chainId) => this.setCurrentChain(chainId));
+    this.commonJRPCProvider.on("chainChanged", async (chainId) => {
+      await this.setCurrentChain(chainId);
+    });
   }
 
   protected async setupConnector(connector: IConnector<unknown>): Promise<void> {
@@ -1367,10 +1369,18 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
    */
   protected getInitialChainIdForConnector(connector: IConnector<unknown>): CustomChainConfig {
     let initialChain = this.currentChain;
-    if (initialChain?.chainNamespace !== connector.connectorNamespace && connector.connectorNamespace !== CONNECTOR_NAMESPACES.MULTICHAIN) {
+    const defaultChainId = this.coreOptions.defaultChainId;
+    const isMultiChainConnector = connector.connectorNamespace === CONNECTOR_NAMESPACES.MULTICHAIN;
+
+    // if the connector is a multi-chain connector and a default chain id is set, use the default chain id
+    if (isMultiChainConnector && defaultChainId) {
+      initialChain = this.coreOptions.chains.find((chain) => chain.chainId === defaultChainId);
+    } else if (initialChain?.chainNamespace !== connector.connectorNamespace && connector.connectorNamespace !== CONNECTOR_NAMESPACES.MULTICHAIN) {
       initialChain = this.coreOptions.chains.find((x) => x.chainNamespace === connector.connectorNamespace);
-      if (!initialChain) throw WalletInitializationError.invalidParams(`No chain found for ${connector.connectorNamespace}`);
     }
+
+    if (!initialChain) throw WalletInitializationError.invalidParams(`No chain found for ${connector.connectorNamespace}`);
+
     return initialChain;
   }
 

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -119,7 +119,11 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
       chain,
       transport: http(currentChain.rpcTarget),
     }) as Client;
+    // Firstly, try to get the accounts from the existing connected provider with `eth_accounts` method.
+    // We don't wanna do `eth_requestAccounts` method here, coz if the wallet is already connected, it will trigger chainChanged event and unintentionally update the AaProvider re-bind and
+    // re-bind run this again, so we will end up in infinite loop.
     const existingAccounts = ((await eoaProvider.request({ method: METHOD_TYPES.GET_ACCOUNTS })) as string[] | null) ?? [];
+    // only if the existing accounts are not found (that means wallet isn't connected), then we will trigger `eth_requestAccounts` method to get the accounts.
     const [eoaAddress] =
       existingAccounts.length > 0 ? existingAccounts : ((await eoaProvider.request({ method: METHOD_TYPES.ETH_REQUEST_ACCOUNTS })) as [string]);
     const walletClient = createWalletClient({

--- a/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
+++ b/packages/no-modal/src/providers/account-abstraction-provider/providers/AccountAbstractionProvider.ts
@@ -119,7 +119,9 @@ class AccountAbstractionProvider extends BaseProvider<AccountAbstractionProvider
       chain,
       transport: http(currentChain.rpcTarget),
     }) as Client;
-    const [eoaAddress] = (await eoaProvider.request({ method: METHOD_TYPES.ETH_REQUEST_ACCOUNTS })) as [string];
+    const existingAccounts = ((await eoaProvider.request({ method: METHOD_TYPES.GET_ACCOUNTS })) as string[] | null) ?? [];
+    const [eoaAddress] =
+      existingAccounts.length > 0 ? existingAccounts : ((await eoaProvider.request({ method: METHOD_TYPES.ETH_REQUEST_ACCOUNTS })) as [string]);
     const walletClient = createWalletClient({
       account: eoaAddress as Hex,
       chain,

--- a/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
+++ b/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
@@ -9,6 +9,7 @@ import {
   CONNECTOR_EVENTS,
   CONNECTOR_STATUS,
   type CONNECTOR_STATUS_TYPE,
+  IConnectorDataEvent,
   IWeb3Auth,
   type IWeb3AuthState,
   LOGIN_MODE,
@@ -211,6 +212,14 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWeb3A
       setChainId(web3Auth.currentChainId);
       setChainNamespace(web3Auth.currentChain?.chainNamespace ?? null);
     };
+    const connectorDataUpdatedListener = (data: IConnectorDataEvent) => {
+      const updatedData = data.data as { chainId: string };
+      if (updatedData.chainId && chainId !== updatedData.chainId) {
+        setChainId(updatedData.chainId);
+        setChainNamespace(web3Auth.currentChain?.chainNamespace);
+      }
+    };
+
     if (web3Auth) {
       web3Auth.on(CONNECTOR_EVENTS.NOT_READY, notReadyListener);
       web3Auth.on(CONNECTOR_EVENTS.READY, readyListener);
@@ -222,6 +231,7 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWeb3A
       web3Auth.on(CONNECTOR_EVENTS.REHYDRATION_ERROR, rehydrationErrorListener);
       web3Auth.on(CONNECTOR_EVENTS.MFA_ENABLED, mfaEnabledListener);
       web3Auth.on(CONNECTOR_EVENTS.CONNECTION_UPDATED, connectionUpdatedListener);
+      web3Auth.on(CONNECTOR_EVENTS.CONNECTOR_DATA_UPDATED, connectorDataUpdatedListener);
 
       if (web3Auth.loginMode === LOGIN_MODE.MODAL) {
         web3Auth.on(CONNECTOR_EVENTS.CONSENT_ACCEPTED, consentAcceptedListener);
@@ -239,6 +249,7 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWeb3A
       web3Auth.removeListener(CONNECTOR_EVENTS.MFA_ENABLED, mfaEnabledListener);
       web3Auth.removeListener(CONNECTOR_EVENTS.AUTHORIZED, authorizedListener);
       web3Auth.removeListener(CONNECTOR_EVENTS.CONNECTION_UPDATED, connectionUpdatedListener);
+      web3Auth.removeListener(CONNECTOR_EVENTS.CONNECTOR_DATA_UPDATED, connectorDataUpdatedListener);
 
       if (web3Auth.loginMode === LOGIN_MODE.MODAL) {
         web3Auth.removeListener(CONNECTOR_EVENTS.CONSENT_ACCEPTED, consentAcceptedListener);

--- a/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
+++ b/packages/no-modal/src/react/context/useWeb3AuthInnerContextValue.ts
@@ -214,7 +214,7 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWeb3A
     };
     const connectorDataUpdatedListener = (data: IConnectorDataEvent) => {
       const updatedData = data.data as { chainId: string };
-      if (updatedData.chainId && chainId !== updatedData.chainId) {
+      if (updatedData.chainId) {
         setChainId(updatedData.chainId);
         setChainNamespace(web3Auth.currentChain?.chainNamespace);
       }

--- a/packages/no-modal/src/react/solana/provider.ts
+++ b/packages/no-modal/src/react/solana/provider.ts
@@ -4,7 +4,7 @@ import { SolanaProvider as SolanaProviderBase } from "@solana/react-hooks";
 import type { ComponentProps } from "react";
 import { createElement, PropsWithChildren, useEffect, useRef, useState } from "react";
 
-import { CHAIN_NAMESPACES, log } from "../../base";
+import { CHAIN_NAMESPACES, type Connection, getCaipChainId, log } from "../../base";
 import type { CustomChainConfig } from "../../base/chain/IChainInterface";
 import { useChain, useWeb3Auth } from "../hooks";
 
@@ -33,19 +33,42 @@ function makePlaceholder(rpc: Pick<CustomChainConfig, "rpcTarget" | "wsTarget">)
 }
 
 function dispose(client: SolanaClient) {
-  void client.actions.disconnectWallet().catch(() => {});
   client.destroy();
 }
 
+function resolveSolanaChain(web3Auth: ReturnType<typeof useWeb3Auth>["web3Auth"], connection: Connection | null) {
+  const currentChain = web3Auth?.currentChain;
+  if (currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
+    return currentChain;
+  }
+
+  const connectedScope =
+    connection?.solanaWallet && "scope" in connection.solanaWallet && typeof connection.solanaWallet.scope === "string"
+      ? connection.solanaWallet.scope
+      : null;
+
+  if (connectedScope) {
+    const connectedChain = web3Auth?.coreOptions.chains?.find((chain) => {
+      return chain.chainNamespace === CHAIN_NAMESPACES.SOLANA && getCaipChainId(chain) === connectedScope;
+    });
+    if (connectedChain) return connectedChain;
+  }
+
+  return web3Auth?.coreOptions.chains?.find((chain) => chain.chainNamespace === CHAIN_NAMESPACES.SOLANA) || null;
+}
+
 /**
- * Builds the SolanaClient for Framework Kit React hooks: placeholder when idle, Web3Auth-backed when
- * connected on Solana. Ref + state so React re-renders on swap and effects dispose the right instance.
+ * Builds the SolanaClient for Framework Kit React hooks.
+ * For multichain wallets, keep the Solana client warm across namespace switches so
+ * switching back to Solana can reuse the existing wallet session.
  */
 function useFrameworkKitSolanaClient(): SolanaClient {
   const { isConnected, connection, web3Auth, isInitialized } = useWeb3Auth();
   const { chainId, chainNamespace } = useChain();
 
   const ref = useRef<SolanaClient | null>(null);
+  const connectedClientRef = useRef<SolanaClient | null>(null);
+  const connectedClientKeyRef = useRef<string | null>(null);
   const [client, setClient] = useState<SolanaClient>(() => {
     const c = makePlaceholder({ rpcTarget: DEVNET_ENDPOINT });
     ref.current = c;
@@ -58,11 +81,17 @@ function useFrameworkKitSolanaClient(): SolanaClient {
 
   useEffect(
     () => () => {
+      const connectedClient = connectedClientRef.current;
       const c = ref.current;
       if (c) {
         dispose(c);
         ref.current = null;
       }
+      if (connectedClient && connectedClient !== c) {
+        dispose(connectedClient);
+      }
+      connectedClientRef.current = null;
+      connectedClientKeyRef.current = null;
     },
     []
   );
@@ -84,37 +113,50 @@ function useFrameworkKitSolanaClient(): SolanaClient {
 
     (async () => {
       const rpc = placeholderRpc(isInitialized, web3Auth);
-      const solanaWallet = connection?.solanaWallet;
-      const onSolana =
-        isConnected &&
-        Boolean(solanaWallet) &&
-        chainNamespace === CHAIN_NAMESPACES.SOLANA &&
-        web3Auth?.currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA;
-
-      if (!onSolana) {
-        adopt(makePlaceholder(rpc));
-        return;
-      }
-
       const conn = connection;
-      if (!conn || !solanaWallet) {
+      const currentChain = web3Auth?.currentChain;
+      const preferredSolanaChain = resolveSolanaChain(web3Auth, conn);
+      const shouldKeepSolanaClient =
+        isConnected &&
+        Boolean(conn?.solanaWallet) &&
+        Boolean(preferredSolanaChain) &&
+        // only manage the client for the primary connector
+        conn?.connectorName === web3Auth?.primaryConnectorName;
+
+      if (!shouldKeepSolanaClient) {
+        connectedClientKeyRef.current = null;
+        const connectedClient = connectedClientRef.current;
+        connectedClientRef.current = null;
+        if (connectedClient) {
+          dispose(connectedClient);
+        }
         adopt(makePlaceholder(rpc));
         return;
       }
 
-      // only reconnect for the primary connector
-      if (conn.connectorName !== web3Auth?.primaryConnectorName) {
-        adopt(makePlaceholder(rpc));
+      const nextClientKey = [
+        conn.connectorName,
+        preferredSolanaChain.chainId,
+        preferredSolanaChain.rpcTarget,
+        preferredSolanaChain.wsTarget || "",
+      ].join(":");
+
+      if (connectedClientRef.current && connectedClientKeyRef.current === nextClientKey) {
+        if (chainNamespace === CHAIN_NAMESPACES.SOLANA && currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
+          adopt(connectedClientRef.current);
+        } else {
+          adopt(makePlaceholder(rpc));
+        }
         return;
       }
 
       try {
         const solanaWalletId = "wallet-standard:" + conn.connectorName;
-        const connector = createWalletStandardConnector(solanaWallet, {
+        const connector = createWalletStandardConnector(conn.solanaWallet, {
           id: solanaWalletId,
           name: conn.connectorName,
         });
-        const { rpcTarget, wsTarget } = web3Auth.currentChain;
+        const { rpcTarget, wsTarget } = preferredSolanaChain;
         const wired = createClient({
           endpoint: rpcTarget,
           websocketEndpoint: wsTarget,
@@ -125,7 +167,17 @@ function useFrameworkKitSolanaClient(): SolanaClient {
           dispose(wired);
           return;
         }
-        adopt(wired);
+        const prevConnectedClient = connectedClientRef.current;
+        connectedClientRef.current = wired;
+        connectedClientKeyRef.current = nextClientKey;
+        if (chainNamespace === CHAIN_NAMESPACES.SOLANA && currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
+          adopt(wired);
+        } else {
+          adopt(makePlaceholder(rpc));
+        }
+        if (prevConnectedClient && prevConnectedClient !== wired) {
+          dispose(prevConnectedClient);
+        }
       } catch (e) {
         log.error("Failed to create or connect Solana client", e);
         adopt(makePlaceholder(rpc));

--- a/packages/no-modal/src/react/solana/provider.ts
+++ b/packages/no-modal/src/react/solana/provider.ts
@@ -66,12 +66,11 @@ function useFrameworkKitSolanaClient(): SolanaClient {
   const { isConnected, connection, web3Auth, isInitialized } = useWeb3Auth();
   const { chainId, chainNamespace } = useChain();
 
-  const ref = useRef<SolanaClient | null>(null);
+  const solClientRef = useRef<SolanaClient | null>(null);
   const connectedClientRef = useRef<SolanaClient | null>(null);
-  const connectedClientKeyRef = useRef<string | null>(null);
   const [client, setClient] = useState<SolanaClient>(() => {
     const c = makePlaceholder({ rpcTarget: DEVNET_ENDPOINT });
-    ref.current = c;
+    solClientRef.current = c;
     return c;
   });
 
@@ -82,16 +81,15 @@ function useFrameworkKitSolanaClient(): SolanaClient {
   useEffect(
     () => () => {
       const connectedClient = connectedClientRef.current;
-      const c = ref.current;
-      if (c) {
-        dispose(c);
-        ref.current = null;
+      const currentClient = solClientRef.current;
+      if (currentClient) {
+        dispose(currentClient);
+        solClientRef.current = null;
       }
-      if (connectedClient && connectedClient !== c) {
+      if (connectedClient && connectedClient !== currentClient) {
         dispose(connectedClient);
       }
       connectedClientRef.current = null;
-      connectedClientKeyRef.current = null;
     },
     []
   );
@@ -99,22 +97,26 @@ function useFrameworkKitSolanaClient(): SolanaClient {
   useEffect(() => {
     let stale = false;
 
-    const adopt = (next: SolanaClient) => {
+    const adopt = (nextClient: SolanaClient) => {
       if (stale) {
-        dispose(next);
+        dispose(nextClient);
         return;
       }
-      const prev = ref.current;
-      if (prev === next) return;
-      if (prev) dispose(prev);
-      ref.current = next;
-      setClient(next);
+      const prevClient = solClientRef.current;
+      if (prevClient === nextClient) return;
+      if (prevClient) dispose(prevClient);
+      solClientRef.current = nextClient;
+      setClient(nextClient);
     };
 
     (async () => {
       const rpc = placeholderRpc(isInitialized, web3Auth);
       const conn = connection;
       const currentChain = web3Auth?.currentChain;
+      if (currentChain?.chainNamespace !== CHAIN_NAMESPACES.SOLANA) {
+        adopt(makePlaceholder(rpc));
+        return;
+      }
       const preferredSolanaChain = resolveSolanaChain(web3Auth, conn);
       const shouldKeepSolanaClient =
         isConnected &&
@@ -124,29 +126,12 @@ function useFrameworkKitSolanaClient(): SolanaClient {
         conn?.connectorName === web3Auth?.primaryConnectorName;
 
       if (!shouldKeepSolanaClient) {
-        connectedClientKeyRef.current = null;
         const connectedClient = connectedClientRef.current;
         connectedClientRef.current = null;
         if (connectedClient) {
           dispose(connectedClient);
         }
         adopt(makePlaceholder(rpc));
-        return;
-      }
-
-      const nextClientKey = [
-        conn.connectorName,
-        preferredSolanaChain.chainId,
-        preferredSolanaChain.rpcTarget,
-        preferredSolanaChain.wsTarget || "",
-      ].join(":");
-
-      if (connectedClientRef.current && connectedClientKeyRef.current === nextClientKey) {
-        if (chainNamespace === CHAIN_NAMESPACES.SOLANA && currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
-          adopt(connectedClientRef.current);
-        } else {
-          adopt(makePlaceholder(rpc));
-        }
         return;
       }
 
@@ -169,7 +154,6 @@ function useFrameworkKitSolanaClient(): SolanaClient {
         }
         const prevConnectedClient = connectedClientRef.current;
         connectedClientRef.current = wired;
-        connectedClientKeyRef.current = nextClientKey;
         if (chainNamespace === CHAIN_NAMESPACES.SOLANA && currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
           adopt(wired);
         } else {

--- a/packages/no-modal/src/vue/solana/provider.ts
+++ b/packages/no-modal/src/vue/solana/provider.ts
@@ -43,7 +43,7 @@ export const SolanaProvider = defineComponent({
     const { chainId } = useChain();
     const clientRef = ref<SolanaClient | null>(null);
     let connectedClient: SolanaClient | null = null;
-    let connectedClientKey: string | null = null;
+    // let connectedClientKey: string | null = null;
     // Holds the token for the newest requested sync run. Older async runs compare against it
     // before publishing results so a slower reconnect cannot overwrite a newer chain/account update.
     let activeSyncToken: symbol | null = null;
@@ -60,6 +60,9 @@ export const SolanaProvider = defineComponent({
       const newIsConnected = isConnected.value;
       const newConnection = connection.value;
       const currentChain = web3Auth.value?.currentChain;
+      if (currentChain?.chainNamespace !== CHAIN_NAMESPACES.SOLANA) {
+        return;
+      }
       const preferredSolanaChain = resolveSolanaChain(web3Auth.value, newConnection);
       const shouldKeepSolanaClient =
         newIsConnected &&
@@ -72,22 +75,10 @@ export const SolanaProvider = defineComponent({
         clientRef.value = null;
         const prevClient = connectedClient;
         connectedClient = null;
-        connectedClientKey = null;
+        // connectedClientKey = null;
         if (prevClient) {
           await disposeClient(prevClient);
         }
-        return;
-      }
-
-      const nextClientKey = [
-        newConnection.connectorName,
-        preferredSolanaChain.chainId,
-        preferredSolanaChain.rpcTarget,
-        preferredSolanaChain.wsTarget || "",
-      ].join(":");
-
-      if (connectedClient && connectedClientKey === nextClientKey) {
-        clientRef.value = currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA ? connectedClient : null;
         return;
       }
 
@@ -119,7 +110,7 @@ export const SolanaProvider = defineComponent({
         }
         const prevClient = connectedClient;
         connectedClient = client;
-        connectedClientKey = nextClientKey;
+        // connectedClientKey = nextClientKey;
         clientRef.value = currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA ? client : null;
         if (prevClient) {
           await disposeClient(prevClient);

--- a/packages/no-modal/src/vue/solana/provider.ts
+++ b/packages/no-modal/src/vue/solana/provider.ts
@@ -1,5 +1,5 @@
 import { createClient, createWalletStandardConnector, type SolanaClient } from "@solana/client";
-import { defineComponent, Fragment, h, provide, ref, watch } from "vue";
+import { defineComponent, Fragment, h, onBeforeUnmount, provide, ref, watch } from "vue";
 
 import { type Connection, getCaipChainId, log } from "../../base";
 import { CHAIN_NAMESPACES } from "../../base/chain/IChainInterface";
@@ -61,6 +61,9 @@ export const SolanaProvider = defineComponent({
       const newConnection = connection.value;
       const currentChain = web3Auth.value?.currentChain;
       if (currentChain?.chainNamespace !== CHAIN_NAMESPACES.SOLANA) {
+        // Mirror the React provider behavior: hide the live Solana client from injected
+        // consumers whenever Web3Auth is currently scoped to a non-Solana namespace.
+        clientRef.value = null;
         return;
       }
       const preferredSolanaChain = resolveSolanaChain(web3Auth.value, newConnection);
@@ -135,6 +138,18 @@ export const SolanaProvider = defineComponent({
       },
       { immediate: true }
     );
+
+    onBeforeUnmount(() => {
+      const publishedClient = clientRef.value;
+      clientRef.value = null;
+      const prevClient = connectedClient;
+      connectedClient = null;
+      if (prevClient) {
+        void disposeClient(prevClient);
+      } else if (publishedClient) {
+        void disposeClient(publishedClient);
+      }
+    });
 
     return () => h(Fragment, null, slots.default?.() ?? []);
   },

--- a/packages/no-modal/src/vue/solana/provider.ts
+++ b/packages/no-modal/src/vue/solana/provider.ts
@@ -1,24 +1,40 @@
 import { createClient, createWalletStandardConnector, type SolanaClient } from "@solana/client";
 import { defineComponent, Fragment, h, provide, ref, watch } from "vue";
 
-import { log } from "../../base";
+import { type Connection, getCaipChainId, log } from "../../base";
 import { CHAIN_NAMESPACES } from "../../base/chain/IChainInterface";
 import { useChain, useWeb3Auth } from "../composables";
 import { SOLANA_CLIENT_KEY } from "./constants";
 
 const disposeClient = async (client: SolanaClient) => {
-  try {
-    await client.actions.disconnectWallet();
-  } catch (e) {
-    log.warn("Solana client disconnect", e);
-  }
   client.destroy();
+};
+
+const resolveSolanaChain = (web3Auth: ReturnType<typeof useWeb3Auth>["web3Auth"]["value"], connection: Connection | null) => {
+  const currentChain = web3Auth?.currentChain;
+  if (currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA) {
+    return currentChain;
+  }
+
+  const connectedScope =
+    connection?.solanaWallet && "scope" in connection.solanaWallet && typeof connection.solanaWallet.scope === "string"
+      ? connection.solanaWallet.scope
+      : null;
+
+  if (connectedScope) {
+    const connectedChain = web3Auth?.coreOptions.chains?.find((chain) => {
+      return chain.chainNamespace === CHAIN_NAMESPACES.SOLANA && getCaipChainId(chain) === connectedScope;
+    });
+    if (connectedChain) return connectedChain;
+  }
+
+  return web3Auth?.coreOptions.chains?.find((chain) => chain.chainNamespace === CHAIN_NAMESPACES.SOLANA) || null;
 };
 
 /**
  * Syncs Web3Auth Solana connection with Framework Kit client.
- * When user is connected via Web3Auth and current chain is Solana, creates a Framework Kit client
- * with Web3Auth as the wallet connector and connects it (same pattern as Wagmi provider).
+ * For multichain wallets, keep the Solana client warm across namespace switches so
+ * switching back to Solana can reuse the existing wallet session.
  */
 export const SolanaProvider = defineComponent({
   name: "SolanaProvider",
@@ -26,6 +42,8 @@ export const SolanaProvider = defineComponent({
     const { isConnected, connection, web3Auth } = useWeb3Auth();
     const { chainId } = useChain();
     const clientRef = ref<SolanaClient | null>(null);
+    let connectedClient: SolanaClient | null = null;
+    let connectedClientKey: string | null = null;
     // Holds the token for the newest requested sync run. Older async runs compare against it
     // before publishing results so a slower reconnect cannot overwrite a newer chain/account update.
     let activeSyncToken: symbol | null = null;
@@ -42,25 +60,35 @@ export const SolanaProvider = defineComponent({
       const newIsConnected = isConnected.value;
       const newConnection = connection.value;
       const currentChain = web3Auth.value?.currentChain;
-      if (
-        !newIsConnected ||
-        !newConnection?.solanaWallet ||
-        currentChain?.chainNamespace !== CHAIN_NAMESPACES.SOLANA ||
-        // only reconnect for the primary connector
-        newConnection.connectorName !== web3Auth.value?.primaryConnectorName
-      ) {
-        const prevClient = clientRef.value;
+      const preferredSolanaChain = resolveSolanaChain(web3Auth.value, newConnection);
+      const shouldKeepSolanaClient =
+        newIsConnected &&
+        Boolean(newConnection?.solanaWallet) &&
+        Boolean(preferredSolanaChain) &&
+        // only manage the client for the primary connector
+        newConnection?.connectorName === web3Auth.value?.primaryConnectorName;
+
+      if (!shouldKeepSolanaClient) {
         clientRef.value = null;
+        const prevClient = connectedClient;
+        connectedClient = null;
+        connectedClientKey = null;
         if (prevClient) {
           await disposeClient(prevClient);
         }
         return;
       }
 
-      const prevClient = clientRef.value;
-      clientRef.value = null;
-      if (prevClient) {
-        await disposeClient(prevClient);
+      const nextClientKey = [
+        newConnection.connectorName,
+        preferredSolanaChain.chainId,
+        preferredSolanaChain.rpcTarget,
+        preferredSolanaChain.wsTarget || "",
+      ].join(":");
+
+      if (connectedClient && connectedClientKey === nextClientKey) {
+        clientRef.value = currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA ? connectedClient : null;
+        return;
       }
 
       let client: SolanaClient | null = null;
@@ -73,7 +101,7 @@ export const SolanaProvider = defineComponent({
         });
 
         // create a solana client
-        const { rpcTarget, wsTarget } = currentChain;
+        const { rpcTarget, wsTarget } = preferredSolanaChain;
         client = createClient({
           endpoint: rpcTarget,
           websocketEndpoint: wsTarget,
@@ -89,7 +117,13 @@ export const SolanaProvider = defineComponent({
           await disposeClient(client);
           return;
         }
-        clientRef.value = client;
+        const prevClient = connectedClient;
+        connectedClient = client;
+        connectedClientKey = nextClientKey;
+        clientRef.value = currentChain?.chainNamespace === CHAIN_NAMESPACES.SOLANA ? client : null;
+        if (prevClient) {
+          await disposeClient(prevClient);
+        }
       } catch (err) {
         if (client) {
           await disposeClient(client);

--- a/packages/no-modal/src/vue/useWeb3AuthInnerContextValue.ts
+++ b/packages/no-modal/src/vue/useWeb3AuthInnerContextValue.ts
@@ -8,6 +8,7 @@ import {
   CONNECTOR_EVENTS,
   CONNECTOR_STATUS,
   type CONNECTOR_STATUS_TYPE,
+  IConnectorDataEvent,
   type IWeb3Auth,
   IWeb3AuthState,
   log,
@@ -200,6 +201,14 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWatch
         chainNamespace.value = web3Auth.value!.currentChain?.chainNamespace ?? null;
       };
 
+      const connectorDataUpdatedListener = (data: IConnectorDataEvent) => {
+        const updatedData = data.data as { chainId: string };
+        if (updatedData.chainId && chainId.value !== updatedData.chainId) {
+          chainId.value = updatedData.chainId;
+          chainNamespace.value = web3Auth.value!.currentChain?.chainNamespace;
+        }
+      };
+
       if (prevWeb3Auth && newWeb3Auth !== prevWeb3Auth) {
         prevWeb3Auth.removeListener(CONNECTOR_EVENTS.NOT_READY, notReadyListener);
         prevWeb3Auth.removeListener(CONNECTOR_EVENTS.READY, readyListener);
@@ -211,6 +220,7 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWatch
         prevWeb3Auth.removeListener(CONNECTOR_EVENTS.REHYDRATION_ERROR, errorListener);
         prevWeb3Auth.removeListener(CONNECTOR_EVENTS.MFA_ENABLED, mfaEnabledListener);
         prevWeb3Auth.removeListener(CONNECTOR_EVENTS.CONNECTION_UPDATED, connectionUpdatedListener);
+        prevWeb3Auth.removeListener(CONNECTOR_EVENTS.CONNECTOR_DATA_UPDATED, connectorDataUpdatedListener);
         if (prevWeb3Auth.loginMode === LOGIN_MODE.MODAL) {
           prevWeb3Auth.removeListener(CONNECTOR_EVENTS.CONSENT_ACCEPTED, consentAcceptedListener);
         }
@@ -228,6 +238,7 @@ export function useWeb3AuthInnerContextValue<TWeb3Auth extends IWeb3Auth, TWatch
         newWeb3Auth.on(CONNECTOR_EVENTS.REHYDRATION_ERROR, errorListener);
         newWeb3Auth.on(CONNECTOR_EVENTS.MFA_ENABLED, mfaEnabledListener);
         newWeb3Auth.on(CONNECTOR_EVENTS.CONNECTION_UPDATED, connectionUpdatedListener);
+        newWeb3Auth.on(CONNECTOR_EVENTS.CONNECTOR_DATA_UPDATED, connectorDataUpdatedListener);
         if (newWeb3Auth.loginMode === LOGIN_MODE.MODAL) {
           newWeb3Auth.on(CONNECTOR_EVENTS.CONSENT_ACCEPTED, consentAcceptedListener);
         }

--- a/packages/no-modal/test/helpers.ts
+++ b/packages/no-modal/test/helpers.ts
@@ -1,11 +1,11 @@
 import type { Wallet } from "@wallet-standard/base";
 import { type IStorageAdapter, SafeEventEmitter } from "@web3auth/auth";
 
+import { LinkAccountParams, LinkAccountResult, UnlinkAccountResult } from "../src";
 import {
   type AuthTokenInfo,
   CHAIN_NAMESPACES,
   type ChainNamespaceType,
-  type LinkedAccountInfo,
   type Connection,
   CONNECTOR_CATEGORY,
   CONNECTOR_NAMESPACES,
@@ -13,10 +13,8 @@ import {
   type CustomChainConfig,
   type IConnector,
   type IProvider,
-  type LinkAccountParams,
-  type LinkAccountResult,
+  type LinkedAccountInfo,
   type ProjectConfig,
-  type UnlinkAccountResult,
   type UserInfo,
   WALLET_CONNECTORS,
 } from "../src/base";

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -812,7 +812,7 @@ describe("Web3AuthNoModal", () => {
     });
   });
 
-  it("prefers defaultChainId over the first namespace chain when resolving a connector from another namespace", () => {
+  it("uses the first matching namespace chain for namespace-specific connectors from another namespace", () => {
     const solanaChainId = "0x2";
     const defaultEvmChainId = "0xaa36a7";
     const sdk = createSdk(
@@ -828,7 +828,36 @@ describe("Web3AuthNoModal", () => {
     );
     const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
 
+    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe("0x1");
+  });
+
+  it("prefers defaultChainId for multichain connectors", () => {
+    const defaultEvmChainId = "0xaa36a7";
+    const sdk = createSdk({
+      defaultChainId: defaultEvmChainId,
+      chains: [
+        createChain({ chainId: "0x1" }),
+        createChain({ chainId: defaultEvmChainId, displayName: "Sepolia", rpcTarget: "https://rpc.sepolia.org" }),
+      ],
+    });
+    const connector = new MockConnector({
+      name: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: MULTICHAIN_CONNECTOR_NAMESPACE,
+    } as never);
+
     expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(defaultEvmChainId);
+  });
+
+  it("picks the first chain for multichain connectors when no default chain id is set", () => {
+    const sdk = createSdk({
+      chains: [createChain({ chainId: "0x1" }), createChain({ chainId: "0xaa36a7" })],
+    });
+    const connector = new MockConnector({
+      name: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: MULTICHAIN_CONNECTOR_NAMESPACE,
+    } as never);
+
+    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe("0x1");
   });
 
   it("connectTo rejects on ERRORED event", async () => {

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -39,6 +39,10 @@ class TestWeb3AuthNoModal extends Web3AuthNoModal {
     return this.checkIfAutoConnect(connector as unknown as IConnector<unknown>);
   }
 
+  public exposeGetInitialChainIdForConnector(connector: MockConnector) {
+    return this.getInitialChainIdForConnector(connector as unknown as IConnector<unknown>);
+  }
+
   public exposeSetConsentRequired(value: boolean) {
     this.consentRequired = value;
   }
@@ -806,6 +810,25 @@ describe("Web3AuthNoModal", () => {
       ethereumProvider: commonJRPCProvider as never,
       solanaWallet: null,
     });
+  });
+
+  it("prefers defaultChainId over the first namespace chain when resolving a connector from another namespace", () => {
+    const solanaChainId = "0x2";
+    const defaultEvmChainId = "0xaa36a7";
+    const sdk = createSdk(
+      {
+        defaultChainId: defaultEvmChainId,
+        chains: [
+          createChain({ chainId: "0x1" }),
+          createChain({ chainId: defaultEvmChainId, displayName: "Sepolia", rpcTarget: "https://rpc.sepolia.org" }),
+          createChain({ chainNamespace: CHAIN_NAMESPACES.SOLANA, chainId: solanaChainId, rpcTarget: "", ticker: "SOL" }),
+        ],
+      },
+      { currentChainId: solanaChainId }
+    );
+    const connector = new MockConnector({ name: WALLET_CONNECTORS.METAMASK, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
+
+    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(defaultEvmChainId);
   });
 
   it("connectTo rejects on ERRORED event", async () => {

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -226,6 +226,7 @@ describe("Web3AuthNoModal", () => {
 
     expect(sdk.connection).toEqual({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: linkedProvider,
       solanaWallet: null,
     });
@@ -283,11 +284,13 @@ describe("Web3AuthNoModal", () => {
     expect(sdk.exposeGetConnectedWalletConnector()).toBe(primaryConnector);
     expect(connectionUpdatedListener).toHaveBeenCalledWith({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: linkedProvider,
       solanaWallet: null,
     });
     expect(sdk.connection).toEqual({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: linkedProvider,
       solanaWallet: null,
     });
@@ -383,11 +386,13 @@ describe("Web3AuthNoModal", () => {
     expect(updateProviderEngineProxy).not.toHaveBeenCalled();
     expect(connectionUpdatedListener).toHaveBeenCalledWith({
       connectorName: WALLET_CONNECTORS.AUTH,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: (sdk as unknown as { commonJRPCProvider: unknown }).commonJRPCProvider,
       solanaWallet: null,
     });
     expect(sdk.connection).toEqual({
       connectorName: WALLET_CONNECTORS.AUTH,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: (sdk as unknown as { commonJRPCProvider: unknown }).commonJRPCProvider,
       solanaWallet: null,
     });
@@ -503,6 +508,7 @@ describe("Web3AuthNoModal", () => {
     expect(sdk.exposeGetConnectedWalletConnector(activeAccount)).toBe(linkedConnector);
     expect(sdk.connection).toEqual({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: linkedProvider,
       solanaWallet: null,
     });
@@ -620,6 +626,7 @@ describe("Web3AuthNoModal", () => {
     const authProvider = { request: vi.fn() };
     const primaryConnection: Connection = {
       connectorName: WALLET_CONNECTORS.AUTH,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: authProvider as never,
       solanaWallet: null,
     };
@@ -780,6 +787,7 @@ describe("Web3AuthNoModal", () => {
 
     await expect(sdk.connectTo(WALLET_CONNECTORS.METAMASK)).resolves.toEqual({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: commonJRPCProvider as never,
       solanaWallet: null,
     });
@@ -807,6 +815,7 @@ describe("Web3AuthNoModal", () => {
 
     await expect(sdk.connectTo(WALLET_CONNECTORS.METAMASK)).resolves.toEqual({
       connectorName: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: CHAIN_NAMESPACES.EIP155,
       ethereumProvider: commonJRPCProvider as never,
       solanaWallet: null,
     });
@@ -1089,14 +1098,16 @@ describe("Web3AuthNoModal", () => {
 
   it("checkIfAutoConnect returns true only for cached matching connector", () => {
     const sdk = createSdk();
-    (sdk as unknown as { state: Record<string, unknown> }).state = {
+    const state = {
       primaryConnectorName: null,
       cachedConnector: WALLET_CONNECTORS.METAMASK,
+      cachedConnectorNamespace: CHAIN_NAMESPACES.EIP155,
       currentChainId: "0x1",
       idToken: null,
       accessToken: null,
       refreshToken: null,
     };
+    (sdk as unknown as { state: Record<string, unknown> }).state = state;
     const matching = new MockConnector({ name: WALLET_CONNECTORS.METAMASK, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
     const nonMatching = new MockConnector({ name: WALLET_CONNECTORS.AUTH, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
     const multichain = new MockConnector({
@@ -1106,6 +1117,8 @@ describe("Web3AuthNoModal", () => {
 
     expect(sdk.exposeCheckIfAutoConnect(matching)).toBe(true);
     expect(sdk.exposeCheckIfAutoConnect(nonMatching)).toBe(false);
+
+    state.cachedConnectorNamespace = CONNECTOR_NAMESPACES.MULTICHAIN;
     expect(sdk.exposeCheckIfAutoConnect(multichain)).toBe(true);
   });
 });

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -832,12 +832,12 @@ describe("Web3AuthNoModal", () => {
   });
 
   it("prefers defaultChainId for multichain connectors", () => {
-    const defaultEvmChainId = "0xaa36a7";
+    const defaultChainId = "0x65";
     const sdk = createSdk({
-      defaultChainId: defaultEvmChainId,
+      defaultChainId,
       chains: [
         createChain({ chainId: "0x1" }),
-        createChain({ chainId: defaultEvmChainId, displayName: "Sepolia", rpcTarget: "https://rpc.sepolia.org" }),
+        createChain({ chainId: defaultChainId, displayName: "Solana Mainnet", rpcTarget: "https://rpc.ankr.com/solana" }),
       ],
     });
     const connector = new MockConnector({
@@ -845,7 +845,7 @@ describe("Web3AuthNoModal", () => {
       connectorNamespace: MULTICHAIN_CONNECTOR_NAMESPACE,
     } as never);
 
-    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(defaultEvmChainId);
+    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(defaultChainId);
   });
 
   it("picks the first chain for multichain connectors when no default chain id is set", () => {

--- a/packages/no-modal/test/noModal.test.ts
+++ b/packages/no-modal/test/noModal.test.ts
@@ -10,6 +10,7 @@ import {
   CONNECTOR_NAMESPACES,
   CONNECTOR_STATUS,
   IConnector,
+  IWeb3AuthState,
   type LinkedAccountInfo,
   log,
   type WALLET_CONNECTOR_TYPE,
@@ -857,6 +858,41 @@ describe("Web3AuthNoModal", () => {
     expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(defaultChainId);
   });
 
+  it("keeps the current chain for multichain connectors when defaultChainId is not configured in chains", () => {
+    const currentChainId = "0x1";
+    const sdk = createSdk(
+      {
+        defaultChainId: "0x65",
+        chains: [
+          createChain({ chainId: currentChainId }),
+          createChain({ chainId: "0xaa36a7", displayName: "Sepolia", rpcTarget: "https://rpc.sepolia.org" }),
+        ],
+      },
+      { currentChainId }
+    );
+    const connector = new MockConnector({
+      name: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: MULTICHAIN_CONNECTOR_NAMESPACE,
+    } as never);
+
+    expect(sdk.exposeGetInitialChainIdForConnector(connector).chainId).toBe(currentChainId);
+  });
+
+  it("throws for multichain connectors when defaultChainId is not configured in chains and no current chain is available", () => {
+    const sdk = createSdk({
+      defaultChainId: "0x65",
+      chains: [createChain({ chainId: "0x1" }), createChain({ chainId: "0xaa36a7", displayName: "Sepolia", rpcTarget: "https://rpc.sepolia.org" })],
+    });
+    const connector = new MockConnector({
+      name: WALLET_CONNECTORS.METAMASK,
+      connectorNamespace: MULTICHAIN_CONNECTOR_NAMESPACE,
+    } as never);
+
+    expect(() => sdk.exposeGetInitialChainIdForConnector(connector)).toThrow(
+      WalletInitializationError.invalidParams(`No chain found for ${MULTICHAIN_CONNECTOR_NAMESPACE}`)
+    );
+  });
+
   it("picks the first chain for multichain connectors when no default chain id is set", () => {
     const sdk = createSdk({
       chains: [createChain({ chainId: "0x1" }), createChain({ chainId: "0xaa36a7" })],
@@ -1098,7 +1134,7 @@ describe("Web3AuthNoModal", () => {
 
   it("checkIfAutoConnect returns true only for cached matching connector", () => {
     const sdk = createSdk();
-    const state = {
+    const state: IWeb3AuthState = {
       primaryConnectorName: null,
       cachedConnector: WALLET_CONNECTORS.METAMASK,
       cachedConnectorNamespace: CHAIN_NAMESPACES.EIP155,
@@ -1106,8 +1142,9 @@ describe("Web3AuthNoModal", () => {
       idToken: null,
       accessToken: null,
       refreshToken: null,
+      activeAccount: null,
     };
-    (sdk as unknown as { state: Record<string, unknown> }).state = state;
+    (sdk as unknown as { state: IWeb3AuthState }).state = state;
     const matching = new MockConnector({ name: WALLET_CONNECTORS.METAMASK, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
     const nonMatching = new MockConnector({ name: WALLET_CONNECTORS.AUTH, connectorNamespace: CHAIN_NAMESPACES.EIP155 } as never);
     const multichain = new MockConnector({


### PR DESCRIPTION
## Jira Link

https://consensyssoftware.atlassian.net/browse/EMBED-409?atlOrigin=eyJpIjoiMTk2NzFhZWEwMDdhNGI2ZmJjNjJkMzM0OTYxYWNlODYiLCJwIjoiaiJ9

https://consensyssoftware.atlassian.net/browse/EMBED-410?atlOrigin=eyJpIjoiMGQyNGIwZGZhZjhiNDY5YWJmYzI4ZWU4MmMxNWE5ZWUiLCJwIjoiaiJ9

https://consensyssoftware.atlassian.net/browse/EMBED-412?atlOrigin=eyJpIjoiYmZhODcyZjUwZDg0NGQ5ZWE0MzljMTVmYTk0MzY1YjUiLCJwIjoiaiJ9

## Description

Fixes MetaMask multichain chain-selection and rehydration issues so Web3Auth stays aligned with the intended chain across connect, reconnect, and namespace-switch flows.

### What changed

- Fixed MetaMask multichain chain sync so connector state is updated consistently during connect, rehydration, and namespace switching.
- Ensured multichain connectors honor `defaultChainId` when selecting the initial chain.
- Fixed Solana namespace switching behavior so connector data stays aligned even when native wallet chain switching is unavailable.
- Fixed wallet-connect-v2 login in Connect-and-Sign mode.
- Fixed connecting to incorrect connector with the same namespace during rehydration.
- Rebound the primary Ethereum signing proxy / AA provider correctly when switching from Solana back to EVM.
- Updated React/Vue Solana provider handling so connected clients remain usable across namespace switches.
- Added/updated test coverage for multichain default-chain selection behavior.
- Updated the Vue demo so `defaultChainId` selection can mutate init config for easier regression testing.

## How has this been tested?

- Ran `packages/no-modal/test/noModal.test.ts`
- Ran the package/browser Vitest suite for `@web3auth/no-modal`
- Manually tested the Vue demo with:
  - Solana -> disconnect -> MetaMask reconnect flow
  - `defaultChainId` set to a non-first EVM chain
  - namespace switching between EVM and Solana
- Verified AA provider rebinding when switching namespaces

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session rehydration, multichain switching, and AA provider binding—core wallet connection paths—but changes are targeted with added tests and demo QA docs.
> 
> **Overview**
> Fixes **MetaMask multichain** chain alignment on connect, rehydration, and **Solana `switchChain`** (state sync when the wallet has no native Solana switch), and tightens how **initial chain** and **session restore** are chosen.
> 
> **Core SDK (`no-modal` / `modal`):** Connections now carry **`connectorNamespace`**; persisted state adds **`cachedConnectorNamespace`** so rehydration does not auto-connect the wrong connector when the same name exists in another namespace. Multichain connectors can start from **`defaultChainId`**; namespace-specific connectors pick the first chain in their namespace when the active chain differs. On **Solana → EVM** namespace changes, the primary signing proxy / **AA provider** is rebound; AA setup prefers **`eth_accounts`** over **`eth_requestAccounts`** to avoid rebind loops. **WalletConnect** background connects in the modal pass **`getAuthTokenInfo`** in connect-and-sign mode.
> 
> **React/Vue:** Solana Framework Kit clients stay **warm across namespace switches**; hooks listen for **`CONNECTOR_DATA_UPDATED`** to refresh chain context.
> 
> **Demo/docs:** Vue settings reorder chains when **`defaultChainId`** changes; dashboard allows namespace switching for any connected wallet; new **modal/no-modal QA checklists**; dependency bumps in the Vue demo lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 569d2dab704fc633c3855db6f4305df87ab93f1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->