### PR TITLE
fix: fixed metamask EIP-6963 provider for injected wallet

### DIFF
--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -34,6 +34,7 @@ import {
   getSolanaChainByChainConfig,
   type IProvider,
   isUserRejectedError,
+  log,
   type UserInfo,
   WALLET_CONNECTOR_TYPE,
   WALLET_CONNECTORS,
@@ -67,6 +68,12 @@ export interface MetaMaskConnectorSettings {
 export interface MetaMaskConnectorOptions extends BaseConnectorSettings {
   connectorSettings?: MetaMaskConnectorSettings;
 }
+
+// `@metamask/connect-evm` announces its SDK-backed provider over EIP-6963 with this
+// RDNS value. Web3Auth uses the dedicated `metaMaskConnector` for MetaMask, so MIPD
+// discovery should ignore this provider to avoid treating the QR/deeplink transport
+// as a native injected wallet.
+export const METAMASK_ERC_6963_PROVIDER_RDNS = "io.metamask.mmc";
 
 class MetaMaskConnector extends BaseConnector<void> {
   readonly connectorNamespace: ConnectorNamespaceType = CONNECTOR_NAMESPACES.MULTICHAIN;
@@ -193,7 +200,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           dapp,
           eventHandlers: {
             accountsChanged: (_accounts: string[]) => {
-              if (_accounts.length === 0 && this.connected) {
+              if (_accounts.length === 0 && this.multichainClient?.status === "connected") {
                 this.disconnect();
               }
             },
@@ -203,7 +210,7 @@ class MetaMaskConnector extends BaseConnector<void> {
             },
             connect: (_result: { chainId: string; accounts: string[] }) => {},
             disconnect: () => {
-              if (this.connected) {
+              if (this.multichainClient?.status === "connected") {
                 this.disconnect();
               }
             },
@@ -398,7 +405,7 @@ class MetaMaskConnector extends BaseConnector<void> {
   async disconnect(options: { cleanup: boolean } = { cleanup: false }): Promise<void> {
     if (!this.multichainClient) throw WalletLoginError.connectionError("Multichain client is not available");
     this.checkDisconnectionRequirements();
-    await this.clearWalletSession();
+    await this.clearMultichainWalletSessions();
 
     // Disconnect using the multichain client
     await this.multichainClient.disconnect();
@@ -600,6 +607,35 @@ class MetaMaskConnector extends BaseConnector<void> {
       : this.evmProvider
         ? this.coreOptions.chains.find((x) => x.chainId === evmChainId)
         : undefined;
+  }
+
+  private async clearMultichainWalletSessions(): Promise<void> {
+    const addresses = new Set<string>();
+
+    if (this.evmProvider) {
+      const evmAccounts = await this.evmProvider.request<never, string[]>({ method: EVM_METHOD_TYPES.GET_ACCOUNTS });
+      evmAccounts.forEach((account) => addresses.add(account));
+    }
+
+    if (this.solanaProvider) {
+      this.solanaProvider.accounts.forEach((account) => addresses.add(account.address));
+    }
+
+    if (addresses.size === 0) {
+      await this.clearWalletSession();
+      return;
+    }
+
+    // MetaMask can authorize both EVM and Solana accounts in one session, but BaseConnector
+    // caches SIWW tokens under one address at a time. Clear every connected address on disconnect.
+    await Promise.all(
+      Array.from(addresses).map((address) => {
+        this.initSessionManager(address);
+        return this.clearWalletSession();
+      })
+    ).catch((error) => {
+      log.error("Failed to clear multichain wallet sessions", error);
+    });
   }
 }
 

--- a/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
+++ b/packages/no-modal/src/connectors/metamask-connector/metamaskConnector.ts
@@ -200,7 +200,7 @@ class MetaMaskConnector extends BaseConnector<void> {
           dapp,
           eventHandlers: {
             accountsChanged: (_accounts: string[]) => {
-              if (_accounts.length === 0 && this.multichainClient?.status === "connected") {
+              if (_accounts.length === 0 && this.connected) {
                 this.disconnect();
               }
             },
@@ -210,7 +210,7 @@ class MetaMaskConnector extends BaseConnector<void> {
             },
             connect: (_result: { chainId: string; accounts: string[] }) => {},
             disconnect: () => {
-              if (this.multichainClient?.status === "connected") {
+              if (this.connected) {
                 this.disconnect();
               }
             },
@@ -408,7 +408,9 @@ class MetaMaskConnector extends BaseConnector<void> {
     await this.clearMultichainWalletSessions();
 
     // Disconnect using the multichain client
-    await this.multichainClient.disconnect();
+    if (this.multichainClient.status === "connected") {
+      await this.multichainClient.disconnect();
+    }
 
     if (options.cleanup) {
       this.status = CONNECTOR_STATUS.NOT_READY;
@@ -628,14 +630,12 @@ class MetaMaskConnector extends BaseConnector<void> {
 
     // MetaMask can authorize both EVM and Solana accounts in one session, but BaseConnector
     // caches SIWW tokens under one address at a time. Clear every connected address on disconnect.
-    await Promise.all(
-      Array.from(addresses).map((address) => {
-        this.initSessionManager(address);
-        return this.clearWalletSession();
-      })
-    ).catch((error) => {
-      log.error("Failed to clear multichain wallet sessions", error);
-    });
+    for (const address of addresses) {
+      this.initSessionManager(address);
+      await this.clearWalletSession().catch((error) => {
+        log.error("Failed to clear multichain wallet session", error);
+      });
+    }
   }
 }
 

--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -94,7 +94,7 @@ import {
   type AuthConnectorType,
   isAuthConnector,
 } from "./connectors/auth-connector";
-import { metaMaskConnector } from "./connectors/metamask-connector";
+import { METAMASK_ERC_6963_PROVIDER_RDNS, metaMaskConnector } from "./connectors/metamask-connector";
 import { walletServicesPlugin } from "./plugins/wallet-services-plugin";
 import { type AccountAbstractionProvider } from "./providers/account-abstraction-provider";
 import { CommonJRPCProvider } from "./providers/base-provider";
@@ -1024,12 +1024,20 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       if (chainNamespaces.has(CHAIN_NAMESPACES.EIP155)) {
         const { createMipd, injectedEvmConnector } = await import("./connectors/injected-evm-connector");
         const evmMipd = createMipd();
+        // `@metamask/connect-evm` SDK announces its own EIP-6963 provider (`io.metamask.mmc`) so
+        // it can be discovered by generic wallet pickers. We already register MetaMask via
+        // `metaMaskConnector`, so we must exclude the SDK-announced provider here; otherwise
+        // it is misclassified as an injected wallet and the modal shows MetaMask as installed,
+        // even when the user does not have the extension installed.
+        const isNonSdkAnnouncedProvider = (providerDetail: { info: { rdns: string } }) =>
+          providerDetail.info.rdns !== METAMASK_ERC_6963_PROVIDER_RDNS;
         // subscribe to new injected connectors
         evmMipd.subscribe((providerDetails) => {
-          const newConnectors = providerDetails.map((providerDetail) => injectedEvmConnector(providerDetail)(config));
+          const filteredProviderDetails = providerDetails.filter(isNonSdkAnnouncedProvider);
+          const newConnectors = filteredProviderDetails.map((providerDetail) => injectedEvmConnector(providerDetail)(config));
           this.setConnectors(newConnectors);
         });
-        connectorFns.push(...evmMipd.getProviders().map(injectedEvmConnector));
+        connectorFns.push(...evmMipd.getProviders().filter(isNonSdkAnnouncedProvider).map(injectedEvmConnector));
       }
     }
 


### PR DESCRIPTION
## JIRA
https://consensyssoftware.atlassian.net/browse/EMBED-413?atlOrigin=eyJpIjoiMzMxNWExMTUwMGQwNDJjYmEyYTdjODNiZDIwMTU3NjgiLCJwIjoiaiJ9

## Description
MetaMask is shown as installed without extension, and multichain MetaMask disconnect leaves stale SIWW auth cache

## Summary
- fix MetaMask login modal detection so the MetaMask Connect SDK's EIP-6963 provider (`io.metamask.mmc`) is not treated as a native injected wallet
- preserve the expected desktop QR flow when MetaMask extension is not installed
- clear cached SIWW auth sessions for all connected MetaMask EVM and Solana addresses on disconnect in `connect-and-sign` mode

## Root Cause
`@metamask/connect-evm` auto-announces an EIP-6963 provider even without the native MetaMask extension. Our `mipd` discovery path picked up that SDK-announced provider and registered it as an injected connector, which made the modal mark MetaMask as installed and does not proceed to mobile connect option (QR).

Additionally, MetaMask multichain auth tokens are cached per connector name + address, but disconnect cleanup only cleared the session for the currently active address, leaving stale tokens for the other connected namespace.

## Test plan
- [x] On desktop without MetaMask extension installed, open the login modal and confirm MetaMask does not show the installed badge
- [x] On desktop without MetaMask extension installed, click MetaMask and confirm the QR flow is shown
- [x] On desktop with MetaMask extension installed, confirm MetaMask still behaves as an injected wallet
- [x] In `connect-and-sign` mode with MetaMask multichain enabled, connect and authorize with an EVM account and a Solana account
- [x] Disconnect MetaMask and verify cached SIWW auth data is cleared for both connected addresses
- [x] Reopen and reconnect after disconnect to confirm no stale authorization state is reused


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches wallet discovery and connect-and-sign session cleanup for MetaMask; wrong filtering could hide real injected wallets or leave auth state inconsistent.
> 
> **Overview**
> Fixes MetaMask showing as **installed** when only the Connect SDK is present, and stale **SIWW** auth after multichain disconnect.
> 
> **EIP-6963 / injected discovery:** Exports `METAMASK_ERC_6963_PROVIDER_RDNS` (`io.metamask.mmc`) and filters that provider out of MIPD-based injected EVM connector registration in `noModal.ts`, so the SDK-announced provider is not duplicated as a native injected wallet. MetaMask stays on the dedicated `metaMaskConnector` path (extension when present, QR/deeplink when not).
> 
> **Disconnect / auth cache:** `MetaMaskConnector.disconnect` now runs `clearMultichainWalletSessions()`, which clears SIWW sessions for every connected EVM and Solana address (not just the active one), only calls `multichainClient.disconnect()` when status is `connected`, and logs per-address cleanup failures without blocking disconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384c90e5949244e669661bec872af5cd767de954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->