### PR TITLE
if there is only one hidden wallet then show on main page

### DIFF
--- a/packages/modal/src/ui/containers/Login/Login.tsx
+++ b/packages/modal/src/ui/containers/Login/Login.tsx
@@ -381,10 +381,10 @@ function Login(props: LoginProps) {
   };
 
   const installedExternalWallets = useMemo(() => {
-    if (showInstalledExternalWallets) return installedExternalWalletConfig;
+    if (showInstalledExternalWallets || remainingUndisplayedWallets <= 1) return installedExternalWalletConfig;
     // always show MetaMask
     return installedExternalWalletConfig.filter((wallet) => wallet.name === WALLET_CONNECTORS.METAMASK);
-  }, [installedExternalWalletConfig, showInstalledExternalWallets]);
+  }, [installedExternalWalletConfig, showInstalledExternalWallets, remainingUndisplayedWallets]);
 
   const handleConnectWallet = useCallback(
     (e?: ReactMouseEvent<HTMLButtonElement>) => {
@@ -507,7 +507,7 @@ function Login(props: LoginProps) {
           ))}
 
         {/* EXTERNAL WALLETS DISCOVERY */}
-        {remainingUndisplayedWallets > 0 && (
+        {remainingUndisplayedWallets > 1 && (
           <button
             type="button"
             className={cn("w3a--btn wta:justify-between! wta:group wta:relative wta:overflow-hidden", {

--- a/packages/modal/src/ui/containers/Root/Root.tsx
+++ b/packages/modal/src/ui/containers/Root/Root.tsx
@@ -167,15 +167,6 @@ function RootContent(props: RootProps) {
     return installedConnectorButtons.filter((button) => !button.hasInjectedWallet);
   }, [installedConnectorButtons]);
 
-  const topInstalledConnectorButtons = useMemo(() => {
-    const MAX_TOP_INSTALLED_CONNECTORS = 3;
-
-    // make metamask the first button and limit the number of buttons
-    return installedConnectorButtons
-      .sort((a, _) => (a.name === WALLET_CONNECTORS.METAMASK ? -1 : 1))
-      .slice(0, displayInstalledExternalWallets ? MAX_TOP_INSTALLED_CONNECTORS : 1);
-  }, [installedConnectorButtons, displayInstalledExternalWallets]);
-
   const allExternalWallets = useMemo(() => {
     const uniqueButtonSet = new Set();
     return installedConnectorButtons.concat(allRegistryButtons).filter((button) => {
@@ -184,6 +175,21 @@ function RootContent(props: RootProps) {
       return true;
     });
   }, [allRegistryButtons, installedConnectorButtons]);
+
+  const topInstalledConnectorButtons = useMemo(() => {
+    const MAX_TOP_INSTALLED_CONNECTORS = 3;
+
+    // make metamask the first button and limit the number of buttons
+    const sortedButtons = [...installedConnectorButtons].sort((a, _) => (a.name === WALLET_CONNECTORS.METAMASK ? -1 : 1));
+
+    let maxToShow = displayInstalledExternalWallets ? MAX_TOP_INSTALLED_CONNECTORS : 1;
+    // avoid hiding a single installed wallet behind the "All Wallets" button: if collapsing
+    // would leave exactly one wallet undisplayed and it's an installed connector, surface it inline
+    if (sortedButtons.length > maxToShow && allExternalWallets.length - maxToShow === 1) {
+      maxToShow += 1;
+    }
+    return sortedButtons.slice(0, maxToShow);
+  }, [installedConnectorButtons, displayInstalledExternalWallets, allExternalWallets]);
 
   const remainingUndisplayedWallets = useMemo(() => {
     return allExternalWallets.filter((button) => {


### PR DESCRIPTION
## Jira Link
https://consensyssoftware.atlassian.net/browse/EMBED-414?atlOrigin=eyJpIjoiOGUzZGM0MjgzOTNjNDMyMjlhZDcyYmFkMjNlOTFiYjUiLCJwIjoiaiJ9
<!-- Link to the Jira ticket (if applicable) -->

## Description

<!-- Describe your changes in detail -->
If there is only one hidden wallet, then we just show the hidden wallet on the main login list page instead of showing "All wallets" button.

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)
### Before
There is only one hidden wallet which is "Rabby Wallet", and the user has to click to times to use it

https://github.com/user-attachments/assets/da6dc635-1d1d-41f0-87b6-9446f267134e


### After
This video shows when there are **>1 hidden wallet**, **only one hidden wallet**, and **no hidden wallet**

https://github.com/user-attachments/assets/a3d7223e-05b3-4a98-af7e-0e3d8eae8f0e



<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
