### PR TITLE
only hide auth login options if there is no available

### DIFF
--- a/packages/modal/src/modalManager.ts
+++ b/packages/modal/src/modalManager.ts
@@ -586,7 +586,7 @@ export class Web3Auth extends Web3AuthNoModal implements IWeb3AuthModal {
         // if no in app wallet is available then initialize all external wallets in modal
         await this.initExternalConnectors(
           filteredConnectors.filter((x) => x.type === CONNECTOR_CATEGORY.EXTERNAL),
-          { externalWalletsInitialized: true, showExternalWalletsOnly: true, externalWalletsVisibility: true }
+          { externalWalletsInitialized: true, showExternalWalletsOnly: true, externalWalletsVisibility: false }
         );
       }
     }

--- a/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
+++ b/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
@@ -15,7 +15,7 @@ import ConnectWalletQrCode from "./ConnectWalletQrCode";
 import ConnectWalletSearch from "./ConnectWalletSearch";
 
 function ConnectWallet(props: ConnectWalletProps) {
-  const { allRegistryButtons, customConnectorButtons, connectorVisibilityMap, isExternalWalletModeOnly } = props;
+  const { allRegistryButtons, customConnectorButtons, connectorVisibilityMap } = props;
 
   const { bodyState, setBodyState } = useBodyState();
   const { analytics } = useContext(AnalyticsContext);
@@ -286,10 +286,8 @@ function ConnectWallet(props: ConnectWalletProps) {
   const hideBackButton = useMemo(() => {
     // If wallet is selected, show the back button
     if (selectedWallet) return false;
-    // Otherwise, if external wallet mode only, login screen is skipped so back button is not needed
-    if (isExternalWalletModeOnly) return true;
     return false;
-  }, [selectedWallet, isExternalWalletModeOnly]);
+  }, [selectedWallet]);
 
   return (
     <div className="wta:relative wta:flex wta:flex-1 wta:flex-col wta:gap-y-4">

--- a/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.type.ts
+++ b/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.type.ts
@@ -4,5 +4,4 @@ export interface ConnectWalletProps {
   allRegistryButtons: ExternalButton[];
   customConnectorButtons: ExternalButton[];
   connectorVisibilityMap: Record<string, boolean>;
-  isExternalWalletModeOnly?: boolean;
 }

--- a/packages/modal/src/ui/containers/Login/Login.tsx
+++ b/packages/modal/src/ui/containers/Login/Login.tsx
@@ -399,13 +399,6 @@ function Login(props: LoginProps) {
     [analytics, handleExternalWalletBtnClick, installedExternalWallets.length, totalExternalWallets]
   );
 
-  useEffect(() => {
-    if (showExternalWalletButton && !areSocialLoginsVisible && !showPasswordLessInput) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional
-      handleConnectWallet();
-    }
-  }, [showExternalWalletButton, areSocialLoginsVisible, showPasswordLessInput, handleConnectWallet]);
-
   if (showOtpFlow) {
     return (
       <LoginOtp

--- a/packages/modal/src/ui/containers/Root/Root.tsx
+++ b/packages/modal/src/ui/containers/Root/Root.tsx
@@ -268,7 +268,6 @@ function RootContent(props: RootProps) {
                     allRegistryButtons={allRegistryButtons}
                     connectorVisibilityMap={connectorVisibilityMap}
                     customConnectorButtons={customConnectorButtons}
-                    isExternalWalletModeOnly={isExternalWalletModeOnly}
                   />
                 )}
             </>

--- a/packages/modal/src/ui/context/ModalStateContext.tsx
+++ b/packages/modal/src/ui/context/ModalStateContext.tsx
@@ -188,10 +188,8 @@ export const ModalStateProvider: FC<ModalStateProviderProps> = ({ children, stat
 
   // TODO: check if can further refactor this logic
   const shouldShowLoginPage = useMemo(
-    () =>
-      (areSocialLoginsVisible || showPasswordLessInput || !!modalState.externalWalletsConfig[WALLET_CONNECTORS.METAMASK]) &&
-      !modalState.externalWalletsVisibility,
-    [areSocialLoginsVisible, showPasswordLessInput, modalState.externalWalletsVisibility, modalState.externalWalletsConfig]
+    () => (areSocialLoginsVisible || showPasswordLessInput || showExternalWalletButton) && !modalState.externalWalletsVisibility,
+    [areSocialLoginsVisible, showPasswordLessInput, showExternalWalletButton, modalState.externalWalletsVisibility]
   );
 
   const value = useMemo(

--- a/packages/modal/src/ui/i18n/amharic.json
+++ b/packages/modal/src/ui/i18n/amharic.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "የተሳሳተ የስልክ ቁጥር",
     "errors-invalid-number-email": "የተሳሳተ ኢሜይል ወይም የስልክ ቁጥር",
     "errors-required": "አስፈላጊ",
-    "external.all-wallets": "ሁሉም ዋሌቶች",
+    "external.all-wallets": "የሌላዎች ዋሌቶች",
     "external.back": "ወደ ኋላ",
     "external.connect": "በዋሌት ቀጥሉ",
     "external.connect-wallet": "ዋሌት ያገናኙ",

--- a/packages/modal/src/ui/i18n/dutch.json
+++ b/packages/modal/src/ui/i18n/dutch.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Ongeldig telefoonnummer",
     "errors-invalid-number-email": "Ongeldig e-mailadres of telefoonnummer",
     "errors-required": "Vereist",
-    "external.all-wallets": "Alle portemonnees",
+    "external.all-wallets": "Andere portemonnees",
     "external.back": "Terug",
     "external.connect": "Ga verder met een portemonnee",
     "external.connect-wallet": "Verbinden met portemonnee",

--- a/packages/modal/src/ui/i18n/english.json
+++ b/packages/modal/src/ui/i18n/english.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Invalid Phone Number",
     "errors-invalid-number-email": "Invalid Email or Phone Number",
     "errors-required": "Required",
-    "external.all-wallets": "All Wallets",
+    "external.all-wallets": "Other wallets",
     "external.back": "Back",
     "external.connect": "Continue with a wallet",
     "external.connect-wallet": "Connect Wallet",

--- a/packages/modal/src/ui/i18n/french.json
+++ b/packages/modal/src/ui/i18n/french.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Numéro de téléphone invalide",
     "errors-invalid-number-email": "Adresse e-mail ou numéro de téléphone invalide",
     "errors-required": "Champ obligatoire",
-    "external.all-wallets": "Toutes les billeteras",
+    "external.all-wallets": "Autres portefeuilles",
     "external.back": "Retour",
     "external.connect": "Continuer avec un portefeuille",
     "external.connect-wallet": "Connecter le portefeuille",

--- a/packages/modal/src/ui/i18n/german.json
+++ b/packages/modal/src/ui/i18n/german.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Ungültige Telefonnummer",
     "errors-invalid-number-email": "Ungültige E-Mail-Adresse oder Telefonnummer",
     "errors-required": "Erforderlich",
-    "external.all-wallets": "Alle Geldbörsen",
+    "external.all-wallets": "Andere Wallets",
     "external.back": "Zurück",
     "external.connect": "Fahren Sie mit einer Brieftasche fort",
     "external.connect-wallet": "Wallet verbinden",

--- a/packages/modal/src/ui/i18n/japanese.json
+++ b/packages/modal/src/ui/i18n/japanese.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "無効な電話番号",
     "errors-invalid-number-email": "無効なメールアドレスまたは電話番号",
     "errors-required": "必須",
-    "external.all-wallets": "すべてのウォレット",
+    "external.all-wallets": "他のウォレット",
     "external.back": "戻る",
     "external.connect": "ウォレットで続行",
     "external.connect-wallet": "ウォレットを接続",

--- a/packages/modal/src/ui/i18n/korean.json
+++ b/packages/modal/src/ui/i18n/korean.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "유효하지 않은 전화번호",
     "errors-invalid-number-email": "유효하지 않은 이메일 또는 전화번호",
     "errors-required": "필수",
-    "external.all-wallets": "모든 지갑",
+    "external.all-wallets": "다른 지갑",
     "external.back": "뒤로",
     "external.connect": "지갑으로 계속하기",
     "external.connect-wallet": "지갑 연결",

--- a/packages/modal/src/ui/i18n/mandarin.json
+++ b/packages/modal/src/ui/i18n/mandarin.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "电话号码无效",
     "errors-invalid-number-email": "无效的电子邮件或电话号码",
     "errors-required": "必填",
-    "external.all-wallets": "所有钱包",
+    "external.all-wallets": "其他钱包",
     "external.back": "返回",
     "external.connect": "继续使用钱包",
     "external.connect-wallet": "连接钱包",

--- a/packages/modal/src/ui/i18n/portuguese.json
+++ b/packages/modal/src/ui/i18n/portuguese.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Número de telefone inválido",
     "errors-invalid-number-email": "Email ou número de telefone inválido",
     "errors-required": "Obrigatório",
-    "external.all-wallets": "Todas as carteiras",
+    "external.all-wallets": "Outras carteiras",
     "external.back": "Voltar",
     "external.connect": "Continuar com uma carteira",
     "external.connect-wallet": "Conectar carteira",

--- a/packages/modal/src/ui/i18n/spanish.json
+++ b/packages/modal/src/ui/i18n/spanish.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Número de teléfono no válido",
     "errors-invalid-number-email": "Correo electrónico o número de teléfono no válido",
     "errors-required": "Campo obligatorio",
-    "external.all-wallets": "Todas las billeteras",
+    "external.all-wallets": "Otras billeteras",
     "external.back": "Atrás",
     "external.connect": "Conectar con la billetera",
     "external.connect-wallet": "Conectar billetera",

--- a/packages/modal/src/ui/i18n/turkish.json
+++ b/packages/modal/src/ui/i18n/turkish.json
@@ -25,7 +25,7 @@
     "errors-invalid-number": "Geçersiz Telefon Numarası",
     "errors-invalid-number-email": "Geçersiz E-posta veya Telefon Numarası",
     "errors-required": "Zorunlu",
-    "external.all-wallets": "Tüm cüzdanlar",
+    "external.all-wallets": "Diğer cüzdanlar",
     "external.back": "Geri",
     "external.connect": "Cüzdanla devam et",
     "external.connect-wallet": "Cüzdanı Bağla",


### PR DESCRIPTION
## Jira Link

https://consensyssoftware.atlassian.net/browse/EMBED-446

<!-- Link to the Jira ticket (if applicable) -->

## Locales PR

https://github.com/Web3Auth/web3auth-locales/pull/239


## Description
Improves the modal UX when only external wallets are available. The login page is now shown/hidden based on whether any auth login options (social logins, passwordless input, or an external wallet button) are actually available, rather than special-casing MetaMask. This prevents auto-skipping into the wallet list and keeps navigation consistent.


## Changes
- **`ModalStateContext`** — `shouldShowLoginPage` now keys off `showExternalWalletButton` instead of hardcoding a MetaMask check, so the login page is hidden only when there are genuinely no auth login options to show.
- **`Login`** — removed the `useEffect` that auto-invoked `handleConnectWallet()` when only external wallets were visible, avoiding the forced skip into the wallet screen.
- **`ConnectWallet`** — dropped the `isExternalWalletModeOnly` prop and its back-button special-casing; back-button visibility now depends solely on whether a wallet is selected.
  - Removed `isExternalWalletModeOnly` from `ConnectWallet.type.ts` and the prop pass-through in `Root`.
- **`modalManager`** — when initializing external connectors (no in-app wallet available), `externalWalletsVisibility` is set to `false` so the flow renders through the standard modal state instead of forcing the external-only view.
- **i18n** — renamed the `external.all-wallets` label from "All Wallets" to "Other wallets" across all locale files.


<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

### No social/auth enabled

https://github.com/user-attachments/assets/3fcd4792-46f2-4904-bb78-fc1afcf867c6

### No installed wallets example

https://github.com/user-attachments/assets/ae259d33-2dc3-4433-91c4-6caac1285c24


<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-screen routing and when login vs wallet list renders across connector configurations; UX-only but affects all modal connect flows when auth methods are disabled.
> 
> **Overview**
> Fixes modal flow when **only external wallets** are configured: the login screen is no longer skipped or auto-advanced into the wallet list unless there is genuinely nothing to show there.
> 
> **`shouldShowLoginPage`** now treats any visible external-wallet entry point via **`showExternalWalletButton`** (not a MetaMask-only check), so the sign-in page stays available when installed wallets or “other wallets” discovery is offered.
> 
> **`modalManager`** initializes external-only setups with **`externalWalletsVisibility: false`**, avoiding the forced external-only view on open. **`Login`** no longer auto-invokes the wallet list when social/passwordless are off. **`ConnectWallet`** drops **`isExternalWalletModeOnly`** and related back-button hiding.
> 
> Copy update: **`external.all-wallets`** is renamed to **“Other wallets”** across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e6eadd0b9d5f61d23d66fc68508b4fc17ec07f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->