### PR TITLE
live re-theme for auto

### DIFF
--- a/packages/modal/src/ui/context/WidgetContext.tsx
+++ b/packages/modal/src/ui/context/WidgetContext.tsx
@@ -1,5 +1,5 @@
 import { CONNECTOR_INITIAL_AUTHENTICATION_MODE, WALLET_CONNECTOR_TYPE } from "@web3auth/no-modal";
-import { createContext, type FC, type ReactNode, useContext, useMemo } from "react";
+import { createContext, type FC, type ReactNode, useContext, useEffect, useMemo, useState } from "react";
 
 import { browser, ExternalWalletEventType, LoginModalProps, os, platform, SocialLoginEventType } from "../interfaces";
 
@@ -38,7 +38,7 @@ const WidgetContext = createContext<WidgetContextType | undefined>(undefined);
 
 export const WidgetProvider: FC<WidgetProviderProps> = ({
   children,
-  isDark = true,
+  isDark: isDarkProp = true,
   deviceDetails,
   uiConfig,
   handleSocialLoginClick,
@@ -50,6 +50,32 @@ export const WidgetProvider: FC<WidgetProviderProps> = ({
   handleChangeWallet,
   closeModal,
 }) => {
+  const [isDark, setIsDark] = useState(() => {
+    if (uiConfig.mode === "auto" && typeof window !== "undefined" && typeof window.matchMedia === "function") {
+      return window.matchMedia("(prefers-color-scheme: dark)").matches;
+    }
+    return isDarkProp;
+  });
+
+  // When mode is "auto", follow live OS color-scheme changes so the modal re-themes without reopening.
+  useEffect(() => {
+    if (uiConfig.mode !== "auto" || typeof window === "undefined" || typeof window.matchMedia !== "function") {
+      return undefined;
+    }
+
+    const mql = window.matchMedia("(prefers-color-scheme: dark)");
+    const applyPreference = () => {
+      setIsDark(mql.matches);
+      // Keep the CSS `dark` variant in sync with the React context value.
+      document.getElementById("w3a-parent-container")?.classList.toggle("w3a--dark", mql.matches);
+    };
+
+    mql.addEventListener("change", applyPreference);
+    return () => {
+      mql.removeEventListener("change", applyPreference);
+    };
+  }, [uiConfig.mode]);
+
   const appLogo = useMemo(() => {
     return isDark ? uiConfig.logoDark : uiConfig.logoLight;
   }, [isDark, uiConfig.logoDark, uiConfig.logoLight]);


### PR DESCRIPTION
## Jira Link

<!-- Link to the Jira ticket (if applicable) -->

## Description

When `uiConfig.mode` is set to `"auto"`, the Web3Auth modal now follows live OS color-scheme changes. Previously the theme was resolved once from the `isDark` prop, so switching the OS between light and dark mid-session left the open modal on the stale theme. The modal now re-themes instantly without needing to be closed and reopened.

## Changes
- **`WidgetContext` (`packages/modal/src/ui/context/WidgetContext.tsx`)**
  - Renamed the incoming `isDark` prop to `isDarkProp` and derive the effective `isDark` from local state, seeded from `prefers-color-scheme` when `mode === "auto"` (falling back to the prop otherwise).
  - Added a `matchMedia("(prefers-color-scheme: dark)")` listener (active only in `"auto"` mode) that updates the React context value on OS theme changes.
  - Kept the CSS `w3a--dark` variant on `#w3a-parent-container` in sync with the context value so component styling and context state stay aligned.
  - Guarded all `window`/`matchMedia` access for SSR safety and cleaned up the listener on unmount / mode change.

<!-- Describe your changes in detail -->

## How has this been tested?

<!-- Please describe how you tested your changes -->

## Screenshots (if appropriate)

https://github.com/user-attachments/assets/eb922581-fbbe-42df-a731-43bbbd41eae3


<!-- Add screenshots if UI changes are involved -->

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/theming in WidgetContext with SSR guards; no auth, data, or API changes.
> 
> **Overview**
> When **`uiConfig.mode`** is **`"auto"`**, the modal no longer sticks to the theme resolved once from the parent **`isDark`** prop. **`WidgetProvider`** now keeps **`isDark`** in React state (initialized from **`prefers-color-scheme`** when possible) and subscribes to **`matchMedia("(prefers-color-scheme: dark)")`** so an open modal updates light/dark as the OS scheme changes.
> 
> On each scheme change it also toggles **`w3a--dark`** on **`#w3a-parent-container`**, aligning Tailwind’s dark variant with context (e.g. **`appLogo`**). **`window`** / **`matchMedia`** usage is guarded for SSR, and the listener is removed when mode is not auto or on unmount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e66ad1d4f577776c52916fadb5bb2c5583eb62b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->