### PR TITLE
fix: installed wallet login with wallet-discovery disabled

### DIFF
--- a/demo/vue-app-new/package-lock.json
+++ b/demo/vue-app-new/package-lock.json
@@ -51,13 +51,13 @@
     },
     "../../packages/modal": {
       "name": "@web3auth/modal",
-      "version": "11.2.0",
+      "version": "11.3.0",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@toruslabs/base-controllers": "^9.10.0",
         "@toruslabs/http-helpers": "^9.0.0",
         "@web3auth/auth": "^11.8.1",
-        "@web3auth/no-modal": "^11.2.0",
+        "@web3auth/no-modal": "^11.3.0",
         "@web3auth/ws-embed": "^6.1.0",
         "bowser": "^2.14.1",
         "classnames": "^2.5.1",
@@ -140,7 +140,7 @@
     },
     "../../packages/no-modal": {
       "name": "@web3auth/no-modal",
-      "version": "11.2.0",
+      "version": "11.3.0",
       "license": "ISC",
       "dependencies": {
         "@metamask/connect-evm": "^2.0.0",

--- a/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
+++ b/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
@@ -143,13 +143,19 @@ function ConnectWallet(props: ConnectWalletProps) {
   };
 
   const filteredButtons = useMemo(() => {
+    const matchesSearch = (button: ExternalButton) => {
+      if (!walletSearch) return true;
+      const searchLower = walletSearch.toLowerCase();
+      return button.name.toLowerCase().includes(searchLower) || button.displayName?.toLowerCase().includes(searchLower);
+    };
+
     if (walletDiscoverySupported) {
       return [...allUniqueButtons.filter((button) => button.hasInjectedWallet), ...allUniqueButtons.filter((button) => !button.hasInjectedWallet)]
         .sort((a, _) => (a.name === WALLET_CONNECTORS.METAMASK ? -1 : 1))
         .filter((button) => selectedChain === "all" || button.chainNamespaces.includes(selectedChain as ChainNamespaceType))
-        .filter((button) => button.name.toLowerCase().includes(walletSearch.toLowerCase()));
+        .filter(matchesSearch);
     }
-    return installedWalletButtons;
+    return installedWalletButtons.filter(matchesSearch);
   }, [walletDiscoverySupported, installedWalletButtons, walletSearch, allUniqueButtons, selectedChain]);
 
   const externalButtons = useMemo(() => {

--- a/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
+++ b/packages/modal/src/ui/containers/ConnectWallet/ConnectWallet.tsx
@@ -121,12 +121,16 @@ function ConnectWallet(props: ConnectWalletProps) {
     const visibilityMap = connectorVisibilityMap;
     return Object.keys(config).reduce((acc, localConnector) => {
       if (localConnector !== WALLET_CONNECTORS.WALLET_CONNECT_V2 && visibilityMap[localConnector]) {
+        const connectorConfig = config[localConnector as WALLET_CONNECTOR_TYPE];
         acc.push({
           name: localConnector,
-          displayName: config[localConnector as WALLET_CONNECTOR_TYPE].label || localConnector,
-          hasInjectedWallet: config[localConnector as WALLET_CONNECTOR_TYPE].isInjected,
+          displayName: connectorConfig.label || localConnector,
+          hasInjectedWallet: connectorConfig.isInjected,
+          isInstalled: true,
           hasWalletConnect: false,
           hasInstallLinks: false,
+          icon: connectorConfig.icon,
+          chainNamespaces: connectorConfig.chainNamespaces || [],
         });
       }
       return acc;


### PR DESCRIPTION
## Jira Link
- https://consensyssoftware.atlassian.net/browse/EMBED-184
- https://consensyssoftware.atlassian.net/browse/EMBED-185

## Description

Fixes two bugs in the Connect Wallet screen when `modalConfig.hideWalletDiscovery` is enabled (`showWalletDiscovery: false` in the demo).

When wallet discovery is off, the modal skips the wallet registry and shows only installed/configured external connectors. With `externalWalletOnly` enabled, users land directly on this screen (social login is hidden), so both issues are especially visible there.

### 1. External wallet search did not filter results

`filteredButtons` only applied the search query when `walletDiscoverySupported` was true. With discovery disabled, it returned all `installedWalletButtons` unchanged, so typing in the search input had no effect.

**Fix:** Extract a shared `matchesSearch` helper and apply it to `installedWalletButtons` as well. Search matches both connector `name` and `displayName` (e.g. "MetaMask" matches `metamask`).

### 2. Installed wallet login did not trigger (e.g. MetaMask popup)

`installedWalletButtons` was built without `isInstalled: true`. `handleWalletClick` uses that flag to decide whether to call `handleExternalWalletClick` (which opens the wallet connector). Without it, clicks were routed to the wallet-discovery path (QR code / install links) instead of connecting.

**Fix:** Set `isInstalled: true` on installed wallet buttons, along with `icon` and `chainNamespaces` from the connector config, matching the shape used elsewhere (e.g. `installedConnectorButtons` in `Root.tsx`).

## How has this been tested?

Manual testing in `demo/vue-app-new`:

1. Disable **Show Wallet Discovery**
2. Enable **External Wallet Only (Hide Social Login)**
3. Open the login modal
4. **Search:** Type a wallet name in the search input — list filters correctly
5. **Login:** Click MetaMask — extension confirmation popup appears and connection completes

## Screenshots (if appropriate)

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the code style of this project. (run lint)
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI fix in Connect Wallet list/search for the no–wallet-discovery path; no auth or backend changes.
> 
> **Overview**
> Fixes the **Connect Wallet** flow when **wallet discovery** is off (empty or missing wallet registry), so users can search and successfully connect with **installed/injected** connectors only.
> 
> **Installed wallet list entries** now carry the same metadata the click handler expects: `isInstalled: true`, connector **icon**, and **chainNamespaces** from `externalWalletsConfig`. Without these, installed wallets could render but fail or mis-route on selection (e.g. chain picker / connector connect).
> 
> **Search** now filters the installed-only wallet list via a shared `matchesSearch` helper (matches connector **name** and **displayName**), not only the discovery/registry path.
> 
> Lockfile bumps `@web3auth/modal` / `@web3auth/no-modal` **11.2.0 → 11.3.0** in the demo app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad5fcb34182e7dba27a6bf452240a5b72aca6b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->