### PR TITLE
fix: do not mutate frozen request params in wallet middleware

### DIFF
--- a/packages/no-modal/src/providers/ethereum-provider/rpc/walletMiddleware.ts
+++ b/packages/no-modal/src/providers/ethereum-provider/rpc/walletMiddleware.ts
@@ -40,9 +40,9 @@ export function createWalletMiddlewareV2({
 
     const req = p.request;
     const txParams = req.params?.[0] ?? { from: "" };
-    txParams.from = await validateAndNormalizeKeyholder(txParams.from, req);
+    const from = await validateAndNormalizeKeyholder(txParams.from, req);
 
-    return processTransaction(txParams, req);
+    return processTransaction({ ...txParams, from }, req);
   }
 
   async function ethSignTransactionHandler(p: MiddlewareParams<JRPCRequest<[TransactionParams]>>) {
@@ -50,9 +50,9 @@ export function createWalletMiddlewareV2({
 
     const req = p.request;
     const txParams = req.params?.[0] ?? { from: "" };
-    txParams.from = await validateAndNormalizeKeyholder(txParams.from, req);
+    const from = await validateAndNormalizeKeyholder(txParams.from, req);
 
-    return processSignTransaction(txParams, req);
+    return processSignTransaction({ ...txParams, from }, req);
   }
 
   // Message signatures


### PR DESCRIPTION
Fixes #2533

`JRPCEngineV2` deep-freezes every request, so assigning to `txParams.from` throws `TypeError: Cannot assign to read only property 'from'` and every `eth_sendTransaction` / `eth_signTransaction` through the WalletConnect v2 connector fails before reaching the wallet.

Copy the params instead of mutating them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to how tx params are passed; behavior should match prior intent without touching auth or persistence.
> 
> **Overview**
> **Fixes transaction signing when RPC requests are deep-frozen** (`JRPCEngineV2`).
> 
> `eth_sendTransaction` and `eth_signTransaction` no longer assign to `txParams.from` on the incoming param object. They normalize the sender into a separate `from` value and pass **`{ ...txParams, from }`** into `processTransaction` / `processSignTransaction`, so WalletConnect v2 and other frozen-request paths no longer throw before the wallet runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32de59679ae10ddf9d754ef54c2bb98b8419a71b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->