### PR TITLE
fix: bind WalletConnect v2 provider wrapper instead of its inner engine

### DIFF
--- a/packages/no-modal/src/noModal.ts
+++ b/packages/no-modal/src/noModal.ts
@@ -1914,7 +1914,13 @@ export class Web3AuthNoModal extends SafeEventEmitter<Web3AuthNoModalEvents> imp
       ethereumProvider === this.commonJRPCProvider || ethereumProvider === this.aaProvider
         ? (primaryConnectorProvider ?? ethereumProvider)
         : ethereumProvider;
-    let finalProvider = (baseEthereumProvider as IBaseProvider<unknown>)?.provider || (baseEthereumProvider as SafeEventEmitterProvider);
+    // For WalletConnect v2, bind the provider wrapper: its inner `.provider` is a
+    // per-chain engine that is replaced on every chain switch and never emits events,
+    // so binding it leaves commonJRPCProvider on the connect-time chain forever.
+    let finalProvider =
+      connectorName === WALLET_CONNECTORS.WALLET_CONNECT_V2
+        ? (baseEthereumProvider as SafeEventEmitterProvider)
+        : (baseEthereumProvider as IBaseProvider<unknown>)?.provider || (baseEthereumProvider as SafeEventEmitterProvider);
     const { accountAbstractionConfig } = this.coreOptions;
     const is7702 = accountAbstractionConfig?.smartAccountEipStandard === SMART_ACCOUNT_EIP_STANDARD["EIP_7702"];
     const isAaSupportedForCurrentChain =


### PR DESCRIPTION
Fixes #2534

`bindPrimaryEthereumSigningProxy` binds `commonJRPCProvider` to the connector provider's inner engine. For WalletConnect v2 that engine is rebuilt on every chain switch and never emits events, so after a switch the app-facing provider keeps answering the old chain on `eth_chainId` and `chainChanged` never reaches subscribers. wagmi's `switchChain` then hangs indefinitely.

Bind the provider wrapper for WalletConnect v2: it routes `request()` to the current engine and re-emits `chainChanged` on every switch. Other connectors are unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Ethereum signing proxy wiring for WalletConnect v2 sessions; scope is a single conditional branch but incorrect binding would affect all WC v2 chain switches.
> 
> **Overview**
> Fixes stale chain state and hung `switchChain` when the primary wallet is **WalletConnect v2**.
> 
> `bindPrimaryEthereumSigningProxy` used to point `commonJRPCProvider` at the connector’s inner `.provider` engine. For WC v2 that engine is swapped on every chain change and does not emit events, so `eth_chainId` stayed on the connect-time chain and `chainChanged` never reached apps (e.g. wagmi waiting forever).
> 
> For **`WALLET_CONNECT_V2` only**, binding now uses the outer provider wrapper, which forwards `request()` to the current engine and re-emits `chainChanged`. Other connectors still use the previous unwrap logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13bc8e887557ba8c6bb08b498a79ff03a6f66780. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->